### PR TITLE
Add email scope to oauth request

### DIFF
--- a/labellab-server/config/github_passport.js
+++ b/labellab-server/config/github_passport.js
@@ -10,6 +10,7 @@ passport.use(
 		{
 			clientID: process.env.GITHUB_CLIENT_ID,
 			clientSecret: process.env.GITHUB_CLIENT_SECRET,
+      scope: ["read:user", "user:email"],
 			callbackURL:
 				process.env.HOST +
 				":" +
@@ -17,6 +18,7 @@ passport.use(
 				"/api/v1/auth/github/callback"
 		},
 		function(accessToken, refreshToken, profile, cb) {
+      primaryEmail = profile.emails.filter(email => email.primary == true)[0]
 			User.findOne({ githubId: profile.id })
 				.then(currentUser => {
 					if (currentUser) {
@@ -27,7 +29,7 @@ passport.use(
 							githubId: profile.id,
 							username: profile.displayName,
 							thumbnail: profile._json.avatar_url,
-							email: profile._json.email
+							email: primaryEmail.value
 						})
 							.save()
 							.then(newUser => {


### PR DESCRIPTION
# Description

Email field in Github user profile data sometimes return null, so email scope is requested with the OAuth request and collected the primary email from the list of users emails.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] auth.js

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
