### PR TITLE
Edit project cards to show actual project description

### DIFF
--- a/labellab-client/src/components/dashboard/previous.js
+++ b/labellab-client/src/components/dashboard/previous.js
@@ -33,7 +33,7 @@ class PreviousProject extends Component {
                   className="card-headers"
                   header={project.projectName}
                 />
-                <Card.Content description="Image Labelling App" />
+                <Card.Content description={project.projectDescription} />
               </Card>
             ))
           ) : (

--- a/labellab-client/src/components/profile/index.js
+++ b/labellab-client/src/components/profile/index.js
@@ -157,7 +157,7 @@ class Profile extends Component {
                             className="card-headers"
                             header={project.projectName}
                           />
-                          <Card.Content description="Image Labelling App" />
+                          <Card.Content description={project.projectDescription} />
                           <Card.Content extra />
                         </Card>
                       ))


### PR DESCRIPTION
# Description
All project cards used to show _Image Labelling App_ as the description. This has been changed so that the cards now show the actual description of the project.

Fixes #158  (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested by giving a new description to a project and seeing if project card in the dashboard reflected the new change.

**Test Configuration**:

Before:
![ProjectDescription2](https://user-images.githubusercontent.com/9462834/71482740-24d68f00-282a-11ea-8d75-1133fb8ddff0.PNG)

After:
![ProjectDescriptionNew](https://user-images.githubusercontent.com/9462834/71482742-2d2eca00-282a-11ea-9a17-f066f8351a6d.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
