### PR TITLE
Add Delete Project button to project page

### DIFF
--- a/labellab-client/src/actions/project/index.js
+++ b/labellab-client/src/actions/project/index.js
@@ -1,3 +1,38 @@
+import {
+  DELETE_PROJECT_FAILURE,
+  DELETE_PROJECT_REQUEST,
+  DELETE_PROJECT_SUCCESS
+} from '../../constants/project/index'
+
+import FetchApi from '../../utils/FetchAPI'
+
+export const deleteProject = (projectId, callback) => {
+  return dispatch => {
+    dispatch(request())
+    FetchApi('DELETE', '/api/v1/project/delete/' + projectId, null, true)
+      .then(res => {
+        dispatch(success())
+        callback()
+      })
+      .catch(err => {
+        if (err.response) {
+          err.response.data
+            ? dispatch(failure(err.response.data.msg))
+            : dispatch(failure(err.response.statusText, null))
+        }
+      })
+  }
+  function request() {
+    return { type: DELETE_PROJECT_REQUEST }
+  }
+  function success() {
+    return { type: DELETE_PROJECT_SUCCESS }
+  }
+  function failure(error) {
+    return { type: DELETE_PROJECT_FAILURE, payload: error }
+  }
+}
+
 export * from './fetchDetails'
 export * from './member'
 export * from './search'

--- a/labellab-client/src/components/project/css/sidebar.css
+++ b/labellab-client/src/components/project/css/sidebar.css
@@ -1,7 +1,9 @@
 .sidebar-parent {
   width: 25%;
   display: flex;
+  align-items: center;
   flex-direction: column;
+  justify-content: space-between;
 }
 .profile-first-leftbar {
   margin: 1em;
@@ -16,4 +18,7 @@
   display: flex;
   flex-direction: row;
   justify-content: center;
+}
+.delete-project-button {
+  width: 80%;
 }

--- a/labellab-client/src/components/project/sidebar.js
+++ b/labellab-client/src/components/project/sidebar.js
@@ -1,9 +1,13 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
-import { Menu } from 'semantic-ui-react'
+import { Menu, Button, Confirm } from 'semantic-ui-react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { fetchProject } from '../../actions/index'
+import {
+  fetchProject,
+  deleteProject,
+  fetchAllProject
+} from '../../actions/index'
 import './css/sidebar.css'
 
 class ProjectSidebar extends Component {
@@ -15,7 +19,8 @@ class ProjectSidebar extends Component {
   }
   componentDidMount() {
     this.setState({
-      activeItem: window.location.pathname.substring(34)
+      activeItem: window.location.pathname.substring(34),
+      open: false
     })
   }
   imageCallback = () => {
@@ -23,6 +28,29 @@ class ProjectSidebar extends Component {
     fetchProject(project.projectId)
   }
   handleItemClick = (e, { name }) => this.setState({ activeItem: name })
+  handleDeleteProject = () => {
+    this.props.deleteProject(
+      this.props.project.projectId,
+      this.fetchAllProjectCallback
+    )
+  }
+  fetchAllProjectCallback = () => {
+    this.handleClose()
+    fetchAllProject()
+    this.props.history.push({
+      pathname: '/'
+    })
+  }
+  handleOpen = () => {
+    this.setState({
+      open: true
+    })
+  }
+  handleClose = () => {
+    this.setState({
+      open: false
+    })
+  }
   render() {
     const { project } = this.props
     const { activeItem } = this.state
@@ -70,6 +98,18 @@ class ProjectSidebar extends Component {
             </Menu.Item>
           </Menu>
         </div>
+
+        <Button
+          negative
+          className="delete-project-button"
+          onClick={this.handleOpen}
+          content="Delete Project"
+        />
+        <Confirm
+          open={this.state.open}
+          onCancel={this.handleClose}
+          onConfirm={this.handleDeleteProject}
+        />
       </div>
     )
   }
@@ -78,7 +118,9 @@ class ProjectSidebar extends Component {
 ProjectSidebar.propTypes = {
   project: PropTypes.object,
   history: PropTypes.object,
-  fetchProject: PropTypes.func
+  fetchProject: PropTypes.func,
+  fetchAllProject: PropTypes.func,
+  deleteProject: PropTypes.func
 }
 
 const mapStateToProps = state => {
@@ -91,11 +133,14 @@ const mapDispatchToProps = dispatch => {
   return {
     fetchProject: data => {
       return dispatch(fetchProject(data))
+    },
+    fetchAllProject: () => {
+      return dispatch(fetchAllProject())
+    },
+    deleteProject: (projectId, callback) => {
+      return dispatch(deleteProject(projectId, callback))
     }
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ProjectSidebar)
+export default connect(mapStateToProps, mapDispatchToProps)(ProjectSidebar)

--- a/labellab-client/src/components/project/sidebar.js
+++ b/labellab-client/src/components/project/sidebar.js
@@ -29,13 +29,13 @@ class ProjectSidebar extends Component {
   }
   handleItemClick = (e, { name }) => this.setState({ activeItem: name })
   handleDeleteProject = () => {
+    this.handleClose()
     this.props.deleteProject(
       this.props.project.projectId,
       this.fetchAllProjectCallback
     )
   }
   fetchAllProjectCallback = () => {
-    this.handleClose()
     fetchAllProject()
     this.props.history.push({
       pathname: '/'

--- a/labellab-client/src/components/project/team.js
+++ b/labellab-client/src/components/project/team.js
@@ -82,6 +82,11 @@ class TeamIndex extends Component {
             <Loader indeterminate>Removing member :(</Loader>
           </Dimmer>
         ) : null}
+        {actions.isdeletingproject ? (
+          <Dimmer active={actions.isdeletingproject}>
+            <Loader indeterminate>Deleting project :(</Loader>
+          </Dimmer>
+        ) : null}
         <Modal size="small" open={open} onClose={this.close}>
           <Modal.Content>
             <p>Enter Member email:</p>
@@ -179,7 +184,4 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TeamIndex)
+export default connect(mapStateToProps, mapDispatchToProps)(TeamIndex)

--- a/labellab-client/src/constants/project/index.js
+++ b/labellab-client/src/constants/project/index.js
@@ -2,3 +2,6 @@ export * from './member'
 export * from './fetchDetails'
 export * from './search'
 export * from './projectDetails'
+export const DELETE_PROJECT_REQUEST = 'DELETE_PROJECT_REQUEST',
+  DELETE_PROJECT_FAILURE = 'DELETE_PROJECT_FAILURE',
+  DELETE_PROJECT_SUCCESS = 'DELETE_PROJECT_SUCCESS'

--- a/labellab-client/src/reducers/project.js
+++ b/labellab-client/src/reducers/project.js
@@ -25,6 +25,7 @@ const initialState = {
     isinitializing: false,
     isadding: false,
     isdeleting: false,
+    isdeletingproject: false,
     errors: '',
     msg: ''
   },
@@ -162,14 +163,14 @@ const project = (state = initialState, action) => {
       return {
         ...state,
         projectActions: {
-          isdeleting: true
+          isdeletingproject: true
         }
       }
     case DELETE_PROJECT_FAILURE:
       return {
         ...state,
         projectActions: {
-          isdeleting: false,
+          isdeletingproject: false,
           errors: action.payload
         }
       }
@@ -177,7 +178,7 @@ const project = (state = initialState, action) => {
       return {
         ...state,
         projectActions: {
-          isdeleting: true,
+          isdeletingproject: false,
           msg: 'Project removed successfully'
         }
       }

--- a/labellab-client/src/reducers/project.js
+++ b/labellab-client/src/reducers/project.js
@@ -13,7 +13,10 @@ import {
   ADD_MEMBER_SUCCESS,
   DELETE_MEMBER_FAILURE,
   DELETE_MEMBER_REQUEST,
-  DELETE_MEMBER_SUCCESS
+  DELETE_MEMBER_SUCCESS,
+  DELETE_PROJECT_FAILURE,
+  DELETE_PROJECT_REQUEST,
+  DELETE_PROJECT_SUCCESS
 } from '../constants/index'
 const initialState = {
   projectActions: {
@@ -153,6 +156,29 @@ const project = (state = initialState, action) => {
         projectActions: {
           isdeleting: false,
           msg: 'Member removed successfully'
+        }
+      }
+    case DELETE_PROJECT_REQUEST:
+      return {
+        ...state,
+        projectActions: {
+          isdeleting: true
+        }
+      }
+    case DELETE_PROJECT_FAILURE:
+      return {
+        ...state,
+        projectActions: {
+          isdeleting: false,
+          errors: action.payload
+        }
+      }
+    case DELETE_PROJECT_SUCCESS:
+      return {
+        ...state,
+        projectActions: {
+          isdeleting: true,
+          msg: 'Project removed successfully'
         }
       }
     default:


### PR DESCRIPTION
# Description

A __Delete Project__ button is added under the sidebar of the project page. This button deletes the current project. This was added since there was no such functionality in earlier versions.

Fixes #173  (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The button was tested by trying to delete multiple projects.

- [x] Tried to delete a project but clicked __Cancel__. Project was not deleted when seen from dashboard and was also present in MongoDB.
- [x] Tried to delete a project and clicked __OK__. The project was not visible in the dashboard and was also removed from MongoDB.

**Test Configuration**:
The delete button is under the sidebar:
![Delete_1](https://user-images.githubusercontent.com/9462834/71640327-0b13cc80-2cae-11ea-8f2f-7a700ff86fc5.PNG)

Confirmation is requested before deletion:
![Delete_2](https://user-images.githubusercontent.com/9462834/71640333-149d3480-2cae-11ea-8ac2-159b1555d3bd.PNG)

Project is not visible in dashboard anymore:
![Delete_3](https://user-images.githubusercontent.com/9462834/71640338-1e269c80-2cae-11ea-95cf-3dae9d54d560.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
