### PR TITLE
Edit Create Project modal to ask for project description

### DIFF
--- a/labellab-client/src/components/dashboard/css/dashboard.css
+++ b/labellab-client/src/components/dashboard/css/dashboard.css
@@ -1,9 +1,25 @@
-.dashboard-parent{
-    height: 100% !important;
-    width: 100%;
-    background: #e5e5e5;
-    min-height: 100vh !important;
+.dashboard-parent {
+  height: 100% !important;
+  width: 100%;
+  background: #e5e5e5;
+  min-height: 100vh !important;
 }
-.create-project-button{
-    padding: 2em 0;
+.create-project-button {
+  padding: 2em 0;
+}
+
+.modal-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.modal-actions > div {
+  padding-top: 1.5em;
+}
+
+.modal-actions:last-child {
+  display: block;
+  text-align: center;
+  padding-bottom: 1.5em;
 }

--- a/labellab-client/src/components/dashboard/index.js
+++ b/labellab-client/src/components/dashboard/index.js
@@ -33,7 +33,8 @@ class Dashboard extends Component {
       image: '',
       open: false,
       maxSizeError: '',
-      projectName: ''
+      projectName: '',
+      projectDescription: ''
     }
   }
   componentDidMount() {
@@ -104,7 +105,10 @@ class Dashboard extends Component {
   }
   handleProjectSubmit = () => {
     this.props.initProject(
-      { projectName: this.state.projectName },
+      {
+        projectName: this.state.projectName,
+        projectDescription: this.state.projectDescription
+      },
       this.projectCallback
     )
     this.close()
@@ -127,22 +131,34 @@ class Dashboard extends Component {
           <Dimmer active={isinitializing}>
             <Loader indeterminate>Preparing Files</Loader>
           </Dimmer>
-          <Modal size="small" open={open} onClose={this.close}>
-            <Modal.Content>
-              <p>Enter Project Name:</p>
-            </Modal.Content>
+          <Modal size="tiny" open={open} onClose={this.close}>
+            <Modal.Header>
+              <p>Enter Project Details</p>
+            </Modal.Header>
             <Modal.Actions>
-              <Input
-                name="projectName"
-                onChange={this.handleChange}
-                type="text"
-                placeholder="Project name"
-              />
-              <Button
-                positive
-                onClick={this.handleProjectSubmit}
-                content="Create Project"
-              />
+              <div className="modal-actions">
+                <Input
+                  name="projectName"
+                  onChange={this.handleChange}
+                  type="text"
+                  placeholder="Project Name"
+                  label="Name"
+                />
+                <Input
+                  name="projectDescription"
+                  onChange={this.handleChange}
+                  type="text"
+                  placeholder="Project Description"
+                  label="Description"
+                />
+                <div>
+                  <Button
+                    positive
+                    onClick={this.handleProjectSubmit}
+                    content="Create Project"
+                  />
+                </div>
+              </div>
             </Modal.Actions>
           </Modal>
           <div className="create-project-button">
@@ -206,7 +222,4 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Dashboard)
+export default connect(mapStateToProps, mapDispatchToProps)(Dashboard)


### PR DESCRIPTION
# Description

This pull request adds the feature of asking for the project description during project creation. This was done since the project description is an important piece of information for a project and it is better to allow the user to set it before the project is created.

__Note:__ If the description field is left empty, the default description (_Image labelling_) is stored.

Fixes #175  (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This feature was tested by creating a project by giving its name and description and then checking the project page to see if the initial project description was being shown. 

**Test Configuration**:

The modal asks for the description:
![desc_1](https://user-images.githubusercontent.com/9462834/71715803-a0db6300-2e38-11ea-81e7-34f71d48f0b9.PNG)

The input description is stored for the project:
![desc_2](https://user-images.githubusercontent.com/9462834/71715845-c6686c80-2e38-11ea-992f-f8025f6fd61a.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
