### PR TITLE
Edit delete project route to remove images, labels and members of the…

### DIFF
--- a/labellab-server/controller/project/projectControls.js
+++ b/labellab-server/controller/project/projectControls.js
@@ -1,6 +1,8 @@
 let User = require('../../models/user')
 let Project = require('../../models/project')
 let ProjectMembers = require('../../models/projectMembers')
+let Image = require('../../models/image')
+let Label = require('../../models/label')
 
 exports.projectInfo = function(req, res) {
 	User.findOne({
@@ -188,6 +190,43 @@ exports.deleteProject = function(req, res) {
 					.status(400)
 					.send({ success: false, msg: 'Project not found' })
 			}
+
+			Image.deleteMany({
+				project: req.params.id
+			  }).exec(function(err, image) {
+				if (err) {
+				  return res.status(400).send({
+					success: false,
+					msg: 'Unable to connect to database. Please try again.',
+					error: err
+				  })
+				}
+			  })
+		
+			  Label.deleteMany({
+				project: req.params.id
+			  }).exec(function(err, image) {
+				if (err) {
+				  return res.status(400).send({
+					success: false,
+					msg: 'Unable to connect to database. Please try again.',
+					error: err
+				  })
+				}
+			  })
+		
+			  ProjectMembers.deleteMany({
+				projectId: req.params.id
+			  }).exec(function(err, image) {
+				if (err) {
+				  return res.status(400).send({
+					success: false,
+					msg: 'Unable to connect to database. Please try again.',
+					error: err
+				  })
+				}
+			  })
+
 			res.json({
 				success: true,
 				msg: 'Project deleted successfully!',


### PR DESCRIPTION
# Description
These changes will enable the delete project route to also remove the images, labels, and projectmembers documents of the project from the database.

Fixes #180

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This was tested by creating a project and adding images, labels, and project members to it. The number of documents in the respective collections were noted. Then the project was deleted and it was made sure that all the documents related to the project in each collection was removed.

**Test Configuration**:
Before deletion:
![delete_new_1](https://user-images.githubusercontent.com/9462834/71777365-e3ca4180-2fc4-11ea-8321-bd0df9ebca1b.PNG)

After deletion:
![delete_new_2](https://user-images.githubusercontent.com/9462834/71777367-e9278c00-2fc4-11ea-8755-0d8836382a96.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
