### PR TITLE
Fix labeller issue where no image was loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Run npm install in labellab-server folder.
 First you need to create a `.env` file in both labellab-server folder and labellab-client folder and fill it with the template provided in the file `.env.example` which is present in both the folders.<br/> <br/>
 For client side `.env` file:
 ```
-REACT_APP_HOST=localhost
+REACT_APP_HOST=http://localhost:
 REACT_APP_SERVER_ENVIORNMENT=dev
 REACT_APP_SERVER_PORT=4000
 ```

--- a/labellab-client/src/components/labeller/index.js
+++ b/labellab-client/src/components/labeller/index.js
@@ -191,7 +191,4 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(LabelingLoader)
+export default connect(mapStateToProps, mapDispatchToProps)(LabelingLoader)

--- a/labellab-client/src/components/project/images.js
+++ b/labellab-client/src/components/project/images.js
@@ -204,9 +204,7 @@ const Row = ({ image, projectId, style, onDelete, imageId }) => (
     <Table.Cell style={columnStyles[1]}>
       <a
         href={
-          'http://' +
           process.env.REACT_APP_HOST +
-          ':' +
           process.env.REACT_APP_SERVER_PORT +
           `/static/uploads/${image.imageUrl}?${Date.now()}`
         }

--- a/labellab-client/src/utils/FetchAPI.js
+++ b/labellab-client/src/utils/FetchAPI.js
@@ -5,9 +5,7 @@ import { TOKEN_TYPE } from '../constants/index'
 const FetchApi = (method, url, params, TokenValue) => {
   if (process.env.REACT_APP_SERVER_ENVIORNMENT === 'dev') {
     url =
-      'http://' +
       process.env.REACT_APP_HOST +
-      ':' +
       process.env.REACT_APP_SERVER_PORT +
       url
   }


### PR DESCRIPTION
# Description
Clicking on __Edit__ on an image opened up to a blank screen. The image URL has been changed to make sure that the labeller opens up properly.

Fixes #184  (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

3 images and 4 labels were added, after which __Edit__ button was clicked for each image which opened up the labeller properly.

**Test Configuration**:
![labeller_2](https://user-images.githubusercontent.com/9462834/71833710-8b359a00-30d3-11ea-86f4-4e48d4c1c92d.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
