### PR TITLE
Fix image link and make it open image

### DIFF
--- a/labellab-client/src/components/project/images.js
+++ b/labellab-client/src/components/project/images.js
@@ -60,16 +60,15 @@ class ImagesIndex extends Component {
     const value = e.target.value
     this.setState({ [name]: value })
   }
-  removeImage = ()=>{
+  removeImage = () => {
     this.setState({
       image: '',
       file: '',
       imageName: '',
-      showform:  !this.state.showform,
+      showform: !this.state.showform,
       format: ''
     })
   }
- 
 
   render() {
     const { imageActions, project } = this.props
@@ -114,9 +113,9 @@ class ImagesIndex extends Component {
             <Button loading={imageActions.isposting} type="submit">
               Submit
             </Button>
-             <Button onClick={this.removeImage} type="delete">
+            <Button onClick={this.removeImage} type="delete">
               Remove
-            </Button> 
+            </Button>
           </Form>
         ) : null}
         <Table
@@ -191,10 +190,7 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ImagesIndex)
+export default connect(mapStateToProps, mapDispatchToProps)(ImagesIndex)
 
 const columnStyles = [
   { flex: '0 0 80px', lineHeight: '32px' },
@@ -206,15 +202,17 @@ const Row = ({ image, projectId, style, onDelete, imageId }) => (
   <Table.Row style={{ ...style, display: 'flex' }}>
     <Table.Cell style={columnStyles[0]}>{imageId + 1}</Table.Cell>
     <Table.Cell style={columnStyles[1]}>
-      <Link
-        to={
-          process.env.REACT_APP_HOST +':'+
+      <a
+        href={
+          'http://' +
+          process.env.REACT_APP_HOST +
+          ':' +
           process.env.REACT_APP_SERVER_PORT +
           `/static/uploads/${image.imageUrl}?${Date.now()}`
         }
       >
         {image.imageName}
-      </Link>
+      </a>
     </Table.Cell>
     <Table.Cell style={columnStyles[2]}>
       <div>


### PR DESCRIPTION
# Description

The changes enable the image links to open up the image. Earlier, the image links led to a blank page.

Fixes #145   (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

An image was added and its name was clicked. This lead to the image opening up in the same tab.

**Test Configuration**:
Image link:
![image_link_1](https://user-images.githubusercontent.com/9462834/71835614-026d2d00-30d8-11ea-9420-18682d9576d4.PNG)

Opened up image:
![image_link_2](https://user-images.githubusercontent.com/9462834/71835628-08fba480-30d8-11ea-9442-bac2e6ad7fb3.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
