### PR TITLE
Change project labels page to use modal and table

### DIFF
--- a/labellab-client/src/components/project/css/labelItem.css
+++ b/labellab-client/src/components/project/css/labelItem.css
@@ -1,30 +1,10 @@
-.form-card-parent {
-  margin-top: 0.7em;
-  margin-right: 1em;
-  padding: 1em;
-  border: solid 1px #efefef;
-  background: white;
-  box-shadow: rgb(204, 204, 204) 0px 1px 2px;
-}
-.flex {
+.modal-actions {
   display: flex;
+  flex-direction: column;
+  align-items: center;
 }
-.form-card-child {
-  flex: 1;
-  padding: 0 0.5em;
-}
-.form-button-parent {
-  flex: 0 0 auto;
-}
-.form-button-itself {
-  background: transparent;
-  padding: 0;
-}
-.form-card-child-field {
-  padding: 3;
-  font-size: 24;
-  max-width: 400px;
-}
-.create-label {
-  margin-top: 1.5em !important;
+
+.modal-actions > div {
+  padding-bottom: 1.5em;
+  padding-top: 1.5em;
 }

--- a/labellab-client/src/components/project/label/index.js
+++ b/labellab-client/src/components/project/label/index.js
@@ -1,8 +1,24 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { Dimmer, Loader, Button, Form, Icon } from 'semantic-ui-react'
-import { fetchLabels, createLabel, deleteLabel, updateALabel } from '../../../actions/index'
+import {
+  Dimmer,
+  Loader,
+  Button,
+  Container,
+  Icon,
+  Table,
+  Header,
+  Modal,
+  Input,
+  Select
+} from 'semantic-ui-react'
+import {
+  fetchLabels,
+  createLabel,
+  deleteLabel,
+  updateALabel
+} from '../../../actions/index'
 import LabelItem from './labelItem.js'
 import '../css/labelItem.css'
 
@@ -21,9 +37,9 @@ class LabelIndex extends Component {
     }
   }
   toggleForm = () => {
-    this.setState({
-      showform: true
-    })
+    this.setState(prevState => ({
+      showform: !prevState.showform
+    }))
   }
   onChange = (name, data) => {
     this.setState({
@@ -49,15 +65,14 @@ class LabelIndex extends Component {
     })
     fetchLabels(project.projectId)
   }
-  onUpdate = value =>{
+  onUpdate = value => {
     const { updateALabel } = this.props
     let data = {
       name: this.state.name,
-      type: this.state.type,
+      type: this.state.type
     }
-    updateALabel(value.id , data ,this.callback)
+    updateALabel(value.id, data, this.callback)
   }
-
 
   handleDelete = value => {
     const { project, deleteLabel, fetchLabels } = this.props
@@ -71,52 +86,79 @@ class LabelIndex extends Component {
     const { actions, labels } = this.props
     const { showform } = this.state
     return (
-      <div>
+      <Container>
         {actions.isdeleting ? (
           <Dimmer active>
             <Loader indeterminate>Removing Label :)</Loader>
           </Dimmer>
         ) : null}
-        {labels !== undefined &&
-          labels.map((label, index) => (
-            <LabelItem
-              value={label}
-              key={index}
-              onChange={this.onChange}
-              onDelete={this.handleDelete}
-              onUpdate={this.onUpdate}
-            />
-          ))}
-        
-        {showform ? (
-          <div className="form-card-parent">
-            <Form className="form-card flex" onSubmit={this.handleSubmit}>
-              <div className="form-card-child">
-                <Form.Field
-                  placeholder="Label name"
-                  control="input"
-                  defaultValue={value.name}
-                  className="form-card-child-field"
-                  onChange={e => this.onChange(e.target.name, e.target.value)}
-                  name="name"
-                />
-                <Form.Select
-                  label="Label type"
+        <Button onClick={this.toggleForm} positive>
+          Add Label
+        </Button>
+        {labels !== undefined && (
+          <Table color="green" celled padded striped>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell singleLine>S. No.</Table.HeaderCell>
+                <Table.HeaderCell>Label</Table.HeaderCell>
+                <Table.HeaderCell>Type</Table.HeaderCell>
+                <Table.HeaderCell />
+              </Table.Row>
+            </Table.Header>
+
+            <Table.Body>
+              {labels.map((label, index) => (
+                <LabelItem
+                  index={index}
+                  label={label}
                   options={options}
-                  defaultValue={value.type}
-                  onChange={(e, change) =>
-                    this.onChange(change.name, change.value)
-                  }
-                  style={{ maxWidth: 400 }}
-                  name="type"
+                  onChange={this.onChange}
+                  onDelete={this.handleDelete}
+                  onUpdate={this.onUpdate}
                 />
-                <Button type="submit">Create</Button>
+              ))}
+            </Table.Body>
+          </Table>
+        )}
+
+        <Modal
+          size="small"
+          open={this.state.showform}
+          onClose={this.toggleForm}
+        >
+          <Modal.Header>
+            <p>Enter Label Details</p>
+          </Modal.Header>
+          <Modal.Actions>
+            <div className="modal-actions">
+              <Input
+                name="name"
+                type="text"
+                label="Name"
+                placeholder="Label name..."
+                defaultValue={value.name}
+                onChange={e => this.onChange(e.target.name, e.target.value)}
+              />
+              <Select
+                label="Type"
+                options={options}
+                defaultValue={value.type}
+                onChange={(e, change) =>
+                  this.onChange(change.name, change.value)
+                }
+                name="type"
+              />
+              <div>
+                <Button
+                  positive
+                  onClick={this.handleSubmit}
+                  content="Add Label"
+                />
               </div>
-            </Form>
-          </div>
-        ) : null}
-        <Button className="create-label" onClick={this.toggleForm}>Create new Label</Button>
-      </div>
+            </div>
+          </Modal.Actions>
+        </Modal>
+      </Container>
     )
   }
 }
@@ -129,7 +171,7 @@ LabelIndex.propTypes = {
   fetchLabels: PropTypes.func,
   createLabel: PropTypes.func,
   deleteLabel: PropTypes.func,
-  updateALabel: PropTypes.func,
+  updateALabel: PropTypes.func
 }
 
 const mapStateToProps = state => {
@@ -157,7 +199,4 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(LabelIndex)
+export default connect(mapStateToProps, mapDispatchToProps)(LabelIndex)

--- a/labellab-client/src/components/project/label/labelItem.js
+++ b/labellab-client/src/components/project/label/labelItem.js
@@ -1,64 +1,64 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Form, Button, Icon } from 'semantic-ui-react'
+import { Input, Select, Button, Icon, Table, Header } from 'semantic-ui-react'
 import '../css/labelItem.css'
 
-const options = [
-  { key: 'bbox', text: 'Draw a bounding box', value: 'bbox' },
-  { key: 'polygon', text: 'Draw a polygon figure', value: 'polygon' }
-]
-
 class LabelItem extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      changed: false
+    }
+  }
+
   render() {
-    const { value, onChange, onDelete, onUpdate } = this.props
+    const { index, label, options } = this.props
+    const { onChange, onDelete, onUpdate } = this.props
     return (
-      <div className="form-card-parent">
-        <Form className="form-card flex">
-          <div className="form-card-child">
-            <Form.Field
-              placeholder="Label name"
-              control="input"
-              defaultValue={value.name}
-              className="form-card-child-field"
-              onChange={e =>
-                {
-                onChange("name",e.target.value)
-                }
-              }
-            />
-            <Form.Select
-              label="Label type"
-              options={options}
-              defaultValue={value.type}
-              onChange={(e, change) =>
-                onChange("type", change.value )
-              }
-              style={{ maxWidth: 400 }}
-            />
-          </div>
-          <div className="form-button-parent">
-            <Button
-              type="button"
-              className="form-button-itself"
-              onClick={() => onDelete(value)}
-            >
-              <Icon name="trash" />
-            </Button>
-            <Button
-              type="button"
-              className="form-button-itself"
-              onClick={() => onUpdate(value)}
-            >
-              Update
-            </Button>
-          </div>
-        </Form>
-      </div>
+      <Table.Row key={index}>
+        <Table.Cell collapsing>
+          <Header as="h4">{index}</Header>
+        </Table.Cell>
+        <Table.Cell>
+          <Input
+            placeholder="Label name"
+            control="input"
+            defaultValue={label.name}
+            onChange={e => {
+              onChange('name', e.target.value)
+              this.setState({
+                changed: true
+              })
+            }}
+          />
+        </Table.Cell>
+        <Table.Cell>
+          <Select
+            options={options}
+            defaultValue={label.type}
+            onChange={(e, change) => {
+              onChange('type', change.value)
+              this.setState({
+                changed: true
+              })
+            }}
+            style={{ maxWidth: 400 }}
+          />
+        </Table.Cell>
+        <Table.Cell collapsing>
+          <Button type="button" onClick={() => onDelete(label)}>
+            <Icon name="trash" />
+          </Button>
+          <Button
+            onClick={() => onUpdate(label)}
+            disabled={this.state.changed ? false : true}
+          >
+            Update
+          </Button>
+        </Table.Cell>
+      </Table.Row>
     )
   }
 }
 
-export default connect(
-  null,
-  null
-)(LabelItem)
+export default connect(null, null)(LabelItem)


### PR DESCRIPTION
# Description

Earlier, the project labels page was cluttered and hard to use. This pull request makes the following changes:
1. __Add Label__ button at the top of the page
2. Table used for displaying of labels
3. Modal used for adding a new label

Fixes #183  (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

2 new labels were added using the modal. They were then deleted using the delete button in the table.

**Test Configuration**:

The labels table:
![labelling_1](https://user-images.githubusercontent.com/9462834/71915469-cf8f6b80-31a1-11ea-93c1-9b369f8be9cc.PNG)

New label modal:
![labelling_2](https://user-images.githubusercontent.com/9462834/71915477-d5854c80-31a1-11ea-987e-c1913ea96f95.PNG)

New label added:
![labelling_3](https://user-images.githubusercontent.com/9462834/71915485-dc13c400-31a1-11ea-9f3a-6931dfda0634.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
