### PR TITLE
Edit Create Project button to be disabled until name is entered

### DIFF
--- a/labellab-client/src/components/dashboard/index.js
+++ b/labellab-client/src/components/dashboard/index.js
@@ -34,7 +34,8 @@ class Dashboard extends Component {
       open: false,
       maxSizeError: '',
       projectName: '',
-      projectDescription: ''
+      projectDescription: '',
+      invalidDetails: true
     }
   }
   componentDidMount() {
@@ -101,6 +102,16 @@ class Dashboard extends Component {
   handleChange = e => {
     this.setState({
       [e.target.name]: e.target.value
+    }, () => {
+      if(this.state.projectName === '') {
+        this.setState({
+          invalidDetails: true
+        })
+      } else {
+        this.setState({
+          invalidDetails: false
+        })
+      }
     })
   }
   handleProjectSubmit = () => {
@@ -141,7 +152,7 @@ class Dashboard extends Component {
                   name="projectName"
                   onChange={this.handleChange}
                   type="text"
-                  placeholder="Project Name"
+                  placeholder="* Project Name"
                   label="Name"
                 />
                 <Input
@@ -156,6 +167,7 @@ class Dashboard extends Component {
                     positive
                     onClick={this.handleProjectSubmit}
                     content="Create Project"
+                    disabled={this.state.invalidDetails ? true : false}
                   />
                 </div>
               </div>


### PR DESCRIPTION
# Description

Earlier, the __Create Project__ button could still be clicked even if a project name wasn't entered. The new changes disable this button until the user enters a project name.

Fixes #199  (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

__Create Project__ button was clicked without entering a project name, which led to nothing happening. When a name was entered, the button turned green and the project could be created.

**Test Configuration**:

The button is disabled initially:
![name_1](https://user-images.githubusercontent.com/9462834/72084021-c4b31300-3328-11ea-85cb-071b431ef10e.PNG)

Once a name is entered, the button is active:
![name_2](https://user-images.githubusercontent.com/9462834/72084041-cd0b4e00-3328-11ea-8fa9-6fc1e861e3bb.PNG)

And on clicking the button, the project is added:
![name_3](https://user-images.githubusercontent.com/9462834/72084098-e7ddc280-3328-11ea-9d0f-88e945a05029.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
