### PR TITLE
fix adding of image after the second time the add image button is cli…

### DIFF
--- a/labellab-client/src/components/project/css/images.css
+++ b/labellab-client/src/components/project/css/images.css
@@ -47,3 +47,7 @@
   flex: 1;
   outline: 0;
 }
+.file_error{
+  color:red;
+  margin-bottom:1rem;
+}

--- a/labellab-client/src/components/project/images.js
+++ b/labellab-client/src/components/project/images.js
@@ -16,7 +16,8 @@ class ImagesIndex extends Component {
       imageName: '',
       projectId: '',
       showform: false,
-      format: ''
+      format: '',
+      showerror:false
     }
   }
   handleImageChange = e => {
@@ -24,12 +25,14 @@ class ImagesIndex extends Component {
     let reader = new FileReader()
     let file = e.target.files[0]
     reader.onloadend = () => {
+      if(file.type!=='image/png'||'image/jpg'||'image/jpeg'||'image/svg'){
+        this.setState({showerror:true})
+      }
       this.setState({
         image: reader.result,
         file: file,
         format: file.type,
         imageName: file.name,
-        showform: !this.state.showform
       })
     }
     reader.readAsDataURL(file)
@@ -44,12 +47,18 @@ class ImagesIndex extends Component {
       projectId: project.projectId,
       format: format
     }
-    submitImage(data, () => {
-      this.setState({
-        showform: false
-      })
-      fetchProject(project.projectId)
+    submitImage(data, async() => {
+     await fetchProject(project.projectId)
+     this.setState({
+      image: '',
+      file: '',
+      imageName: '',
+      projectId: '',
+      showform: false,
+      format: ''
     })
+    })
+  
   }
   handleDelete = imageId => {
     const { deleteImage, project, fetchProject } = this.props
@@ -90,6 +99,7 @@ class ImagesIndex extends Component {
           <label
             htmlFor="image-embedpollfileinput"
             className="ui medium primary left floated button custom-margin"
+            onClick={()=>{this.setState({showform:!this.state.showform})}}
           >
             Add Image
           </label>
@@ -110,6 +120,7 @@ class ImagesIndex extends Component {
                 placeholder="Image Name"
               />
             </Form.Field>
+            {this.state.showerror?<div className="file_error">The file is not an image</div>:null}
             <Button loading={imageActions.isposting} type="submit">
               Submit
             </Button>
@@ -204,7 +215,6 @@ const Row = ({ image, projectId, style, onDelete, imageId }) => (
     <Table.Cell style={columnStyles[1]}>
       <a
         href={
-          'http://' +
           process.env.REACT_APP_HOST +
           ':' +
           process.env.REACT_APP_SERVER_PORT +


### PR DESCRIPTION

# Description

the add image button was not working when image was not working for the second time. also added error handling for when image is not of the correct format

Fixes #186 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
<img width="935" alt="Screenshot 2020-01-11 at 2 05 05 AM" src="https://user-images.githubusercontent.com/43586052/72184955-a5df7a00-3417-11ea-97d8-e702355ce095.png">

Also, include screenshots of app for the verification and reviewing purpose.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
