### PR TITLE
Edit description editor to use modal

### DIFF
--- a/labellab-client/src/components/project/css/projectDesc.css
+++ b/labellab-client/src/components/project/css/projectDesc.css
@@ -11,17 +11,16 @@
 .projectDesc-header .pencil:hover {
   cursor: pointer;
 }
-.projectDesc-labeller-button {
-  margin: 1em 0;
+
+.modal-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
-.projectDesc-labeller-button button {
-  background-color: #00a89f !important;
-  color: white !important;
-}
-.projectDesc-submit{
-  background-color: #00a89f !important;
-  color: white !important;
-  margin-top: 1em !important; 
+
+.modal-actions > div {
+  padding-bottom: 1.5em;
+  padding-top: 1.5em;
 }
 
 @media only screen and (max-width: 1550px) {

--- a/labellab-client/src/components/project/projectDesc.js
+++ b/labellab-client/src/components/project/projectDesc.js
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types'
 import {
   Header,
   Icon,
-  TextArea,
-  Form,
+  Input,
   Button,
   Dimmer,
-  Loader
+  Loader,
+  Modal
 } from 'semantic-ui-react'
 import { updateProject, fetchProject } from '../../actions/index'
 import './css/projectDesc.css'
@@ -44,10 +44,13 @@ class ProjectDescriptionIndex extends Component {
   }
   callback = () => {
     const { project, fetchProject } = this.props
+    this.close();
+    fetchProject(project.projectId)
+  }
+  close = () => {
     this.setState({
       edit: false
     })
-    fetchProject(project.projectId)
   }
   handleChange = e => {
     this.setState({
@@ -69,21 +72,30 @@ class ProjectDescriptionIndex extends Component {
           <Icon name="pencil alternate" onClick={this.handleUpdate} />
         </div>
         {edit ? (
-          <Form>
-            <TextArea
-              placeholder="Write some project description"
-              value={desc}
-              onChange={this.handleChange}
-              name="desc"
-            />
-            <Button
-              className="projectDesc-submit"
-              floated="right"
-              onClick={this.handleSubmit}
-            >
-              Submit
-            </Button>
-          </Form>
+          <Modal size="small" open={this.state.edit} onClose={this.close}>
+            <Modal.Header>
+              <p>Enter Project Description</p>
+            </Modal.Header>
+            <Modal.Actions>
+              <div className="modal-actions">
+                <Input
+                  name="desc"
+                  type="text"
+                  label="Description"
+                  placeholder="Description..."
+                  defaultValue={this.state.desc}
+                  onChange={this.handleChange}
+                />
+                <div>
+                  <Button
+                    positive
+                    onClick={this.handleSubmit}
+                    content="Submit"
+                  />
+                </div>
+              </div>            
+            </Modal.Actions>
+          </Modal>
         ) : null}
         {!edit && desc ? desc : null}
       </div>


### PR DESCRIPTION
# Description

The project description editor now uses a modal instead of opening a form within the same page.

Fixes #216  (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

A project's description was edited and submitted. The changes could be seen in the project page as well as the dashboard. The same process was done but without changing the description text.

**Test Configuration**:

The modal:
![desc_2](https://user-images.githubusercontent.com/9462834/72223544-ff6db300-3595-11ea-8c11-0f06a1b6e41a.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
