### PR TITLE
Increase urlencoded limit

### DIFF
--- a/labellab-server/app.js
+++ b/labellab-server/app.js
@@ -25,8 +25,8 @@ if (process.env.GITHUB_CLIENT_ID) {
 
 app.use(logger('dev'))
 app.use(cors())
-app.use(express.json())
-app.use(express.urlencoded({ extended: false, limit: '4mb' }))
+app.use(express.json({ limit: '10mb' }))
+app.use(express.urlencoded({ extended: false, limit: '10mb' }))
 app.use(cookieParser())
 app.set('/views', path.join(__dirname, 'views'))
 app.engine('html', require('ejs').renderFile)


### PR DESCRIPTION
# Description
Increased `express.urlencoded({ limit: '10mb' })` to 10mb.
This helps in submitting large images (high-resolution).

Fixes #232 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested on forked repo.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
