### PR TITLE
update pubspec.yaml

### DIFF
--- a/labellab_mobile/pubspec.yaml
+++ b/labellab_mobile/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   sqflite: ^1.1.0
   image_picker: ^0.6.0+9
   intl: ^0.15.8
-  cached_network_image: ^2.0.0
+  cached_network_image: 
   google_sign_in: ^4.0.2
   flutter_webview_plugin: ^0.3.5
   rxdart: ^0.22.0


### PR DESCRIPTION
since cached_ network_image requires Flutter SDK version >=1.10.15-pre.148 <2.0.0 and The current Flutter SDK version is 1.9.1+hotfix.6.
remove the version for cached_ network_image and package get works properly.

