### PR TITLE
Add bulk image upload

### DIFF
--- a/labellab-client/src/components/project/images.js
+++ b/labellab-client/src/components/project/images.js
@@ -11,9 +11,9 @@ class ImagesIndex extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      image: '',
+      images: [],
       file: '',
-      imageName: '',
+      imageNames: [],
       projectId: '',
       showform: false,
       format: ''
@@ -21,32 +21,38 @@ class ImagesIndex extends Component {
   }
   handleImageChange = e => {
     e.preventDefault()
-    let reader = new FileReader()
-    let file = e.target.files[0]
-    reader.onloadend = () => {
-      this.setState({
-        image: reader.result,
-        file: file,
-        format: file.type,
-        imageName: file.name,
-        showform: !this.state.showform
-      })
-    }
-    reader.readAsDataURL(file)
+    let files = e.target.files
+    Array.from(files).forEach(file => {
+      let reader = new FileReader()
+      reader.onloadend = () => {
+        this.setState(prevState => ({
+          images: [...prevState.images, reader.result],
+          file: file,
+          format: file.type,
+          imageNames: [...prevState.imageNames, file.name]
+        }))
+      }
+      reader.readAsDataURL(file)
+    })
+    this.setState({
+      showform: !this.state.showform
+    })
   }
   handleSubmit = e => {
     e.preventDefault()
     const { project, fetchProject, submitImage } = this.props
-    const { imageName, image, format } = this.state
+    const { imageNames, images, format } = this.state
     let data = {
-      imageName: imageName,
-      image: image,
+      imageNames: imageNames,
+      images: images,
       projectId: project.projectId,
       format: format
     }
     submitImage(data, () => {
       this.setState({
-        showform: false
+        showform: false,
+        images: [],
+        imageNames: []
       })
       fetchProject(project.projectId)
     })
@@ -55,16 +61,15 @@ class ImagesIndex extends Component {
     const { deleteImage, project, fetchProject } = this.props
     deleteImage(imageId, project.projectId, fetchProject(project.projectId))
   }
-  handleChange = e => {
-    const name = e.target.name
+  handleNameChange = e => {
     const value = e.target.value
-    this.setState({ [name]: value })
+    this.setState({ imageNames: [value] })
   }
   removeImage = () => {
     this.setState({
-      image: '',
+      images: [],
       file: '',
-      imageName: '',
+      imageNames: [],
       showform: !this.state.showform,
       format: ''
     })
@@ -83,6 +88,7 @@ class ImagesIndex extends Component {
         <div>
           <input
             type="file"
+            multiple
             onChange={this.handleImageChange}
             className="image-file-input"
             id="image-embedpollfileinput"
@@ -101,20 +107,23 @@ class ImagesIndex extends Component {
             encType="multiple/form-data"
             onSubmit={this.handleSubmit}
           >
-            <Form.Field>
-              <label>Image Name</label>
-              <input
-                name="imageName"
-                value={imageName}
-                onChange={this.handleChange}
-                placeholder="Image Name"
-              />
-            </Form.Field>
+            {this.state.images.length == 1 && (
+              <Form.Field>
+                <label>Image Name</label>
+                <input
+                  name="imageName"
+                  value={imageName}
+                  onChange={this.handleNameChange}
+                  placeholder="Image Name"
+                />
+              </Form.Field>
+            )}
+
             <Button loading={imageActions.isposting} type="submit">
               Submit
             </Button>
             <Button onClick={this.removeImage} type="delete">
-              Remove
+              Cancel
             </Button>
           </Form>
         ) : null}


### PR DESCRIPTION
# Description

These changes enable users to upload multiple images at the same time. If 1 image is uploaded, the user can change the name. If multiple images are uploaded, the user can simply click the submit button and all the images will be uploaded with their default name. This was done since labelling projects will need many images which will be cumbersome to upload one-by-one.

Fixes #222  (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] A single image was uploaded and it's name was changed.
- [x] 3 images were uploaded together.

**Test Configuration**:
1. Image selection:
![multiple_images](https://user-images.githubusercontent.com/9462834/72717195-8b8f6400-3bae-11ea-919e-8a7e9840abd2.PNG)

2. Confirmation for multiple images:
![multiple_images_2](https://user-images.githubusercontent.com/9462834/72717010-33586200-3bae-11ea-924e-f7a2c7badeb0.PNG)

3. Uploaded images:
![multiple_images_3](https://user-images.githubusercontent.com/9462834/72717019-39e6d980-3bae-11ea-8169-e36aff1c8d4b.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
