### PR TITLE
Reposition buttons on labels route

### DIFF
--- a/labellab-client/src/components/project/css/labelItem.css
+++ b/labellab-client/src/components/project/css/labelItem.css
@@ -1,5 +1,6 @@
 .form-card-parent {
   margin-top: 0.7em;
+  margin-right: 1em;
   padding: 1em;
   border: solid 1px #efefef;
   background: white;
@@ -22,4 +23,8 @@
 .form-card-child-field {
   padding: 3;
   font-size: 24;
+  max-width: 400px;
+}
+.create-label {
+  margin-top: 1.5em !important;
 }

--- a/labellab-client/src/components/project/label/index.js
+++ b/labellab-client/src/components/project/label/index.js
@@ -87,41 +87,35 @@ class LabelIndex extends Component {
               onUpdate={this.onUpdate}
             />
           ))}
-        <Button onClick={this.toggleForm}>Create new Label</Button>
+        
         {showform ? (
-          <Form className="form-card flex" onSubmit={this.handleSubmit}>
-            <div className="form-card-child">
-              <Form.Field
-                placeholder="Label name"
-                control="input"
-                defaultValue={value.name}
-                className="form-card-child-field"
-                onChange={e => this.onChange(e.target.name, e.target.value)}
-                name="name"
-              />
-              <Form.Select
-                label="Label type"
-                options={options}
-                defaultValue={value.type}
-                onChange={(e, change) =>
-                  this.onChange(change.name, change.value)
-                }
-                style={{ maxWidth: 400 }}
-                name="type"
-              />
-            </div>
-            <div className="form-button-parent">
-              <Button
-                type="button"
-                className="form-button-itself"
-                onClick={this.onChange}
-              >
-                <Icon name="trash" />
-              </Button>
-            </div>
-            <Button type="submit">Create</Button>
-          </Form>
+          <div className="form-card-parent">
+            <Form className="form-card flex" onSubmit={this.handleSubmit}>
+              <div className="form-card-child">
+                <Form.Field
+                  placeholder="Label name"
+                  control="input"
+                  defaultValue={value.name}
+                  className="form-card-child-field"
+                  onChange={e => this.onChange(e.target.name, e.target.value)}
+                  name="name"
+                />
+                <Form.Select
+                  label="Label type"
+                  options={options}
+                  defaultValue={value.type}
+                  onChange={(e, change) =>
+                    this.onChange(change.name, change.value)
+                  }
+                  style={{ maxWidth: 400 }}
+                  name="type"
+                />
+                <Button type="submit">Create</Button>
+              </div>
+            </Form>
+          </div>
         ) : null}
+        <Button className="create-label" onClick={this.toggleForm}>Create new Label</Button>
       </div>
     )
   }


### PR DESCRIPTION
# Description

Repositioned `Create` button on labels route.
Made the new label form similar to `labelItem`.
Removed `trash icon`, while creating new label.

Fixes #141 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
On the Forked repo.

![image](https://user-images.githubusercontent.com/32769793/72898248-b8c44980-3d49-11ea-8ee9-e0aa2bc44c99.png)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
