### PR TITLE
made project labels and images tab responsive

### DIFF
--- a/labellab-client/src/components/project/css/images.css
+++ b/labellab-client/src/components/project/css/images.css
@@ -47,3 +47,8 @@
   flex: 1;
   outline: 0;
 }
+@media only screen and (max-width: 902px){
+  .image-table-body{
+    width: 902px;
+  }
+}

--- a/labellab-client/src/components/project/css/labelItem.css
+++ b/labellab-client/src/components/project/css/labelItem.css
@@ -23,3 +23,18 @@
   padding: 3;
   font-size: 24;
 }
+@media only screen and (max-width: 892px){
+  .form-button-parent{
+    flex: auto;;
+  }
+  .ui.button.form-button-itself{
+    margin-bottom: 2.9em;
+  }
+}
+@media only screen and (max-width: 645px){
+ 
+  .form-card-parent{
+    width: 322px;
+    margin-left: -4em;
+  }
+}


### PR DESCRIPTION
# Description

The project labels page is now responsive and also made a small improvement in project images page.

Fixes #250

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Also, include screenshots of app for the verification and reviewing purpose.
![Screenshot from 2020-01-23 11-36-49](https://user-images.githubusercontent.com/54547503/72961136-21590800-3dd6-11ea-8ebb-862ea2e14869.png)
![Screenshot from 2020-01-23 11-37-53](https://user-images.githubusercontent.com/54547503/72961141-2322cb80-3dd6-11ea-868d-b193f973b037.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
