### PR TITLE
Add "Back to Project" button to labeller

### DIFF
--- a/labellab-client/src/components/labeller/LabelingApp.js
+++ b/labellab-client/src/components/labeller/LabelingApp.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { withRouter } from 'react-router-dom'
 // import Hotkeys from 'react-hot-keys';
 import update from 'immutability-helper'
 
@@ -214,6 +215,7 @@ class LabelingApp extends Component {
     const {
       labels,
       imageUrl,
+      projectUrl,
       // reference,
       onBack,
       onSkip,
@@ -273,7 +275,8 @@ class LabelingApp extends Component {
             pushState(state => ({
               figures: update(figures, { [labelId]: { $set: newValue } })
             })),
-          labelData: figures
+          labelData: figures,
+          onHome: () => this.props.history.push(projectUrl)
         }
     // let selectedFigure = null;
     const allFigures = []
@@ -338,4 +341,4 @@ class LabelingApp extends Component {
   }
 }
 
-export default withLoadImageData(withHistory(LabelingApp))
+export default withLoadImageData(withRouter(withHistory(LabelingApp)))

--- a/labellab-client/src/components/labeller/Sidebar.js
+++ b/labellab-client/src/components/labeller/Sidebar.js
@@ -28,6 +28,7 @@ export default class Sidebar extends PureComponent {
       openHotkeys,
       onBack,
       onSkip,
+      onHome,
       labelData,
       onFormChange,
       models,
@@ -80,8 +81,10 @@ export default class Sidebar extends PureComponent {
           <Hotkeys keyName="esc" onKeyDown={() => onSelect(null)} />
         </List>
         <div style={{ flex: '0 0 auto', display: 'flex' }}>
-          <Button onClick={onBack}>Back</Button>
+          <Button onClick={onHome}>Home</Button>
           <span style={{ flex: 1 }} />
+          <Button onClick={onBack}>Back</Button>
+          <span style={{ flex: 0.3 }} />
           <Button secondary onClick={onSkip}>
             Skip
           </Button>

--- a/labellab-client/src/components/labeller/index.js
+++ b/labellab-client/src/components/labeller/index.js
@@ -120,6 +120,7 @@ class LabelingLoader extends Component {
               process.env.REACT_APP_SERVER_PORT +
               `/static/uploads/${image.imageUrl}?${Date.now()}`
             }
+            projectUrl={`/project/${match.params.projectId}/images`}
             demo={false}
             {...props}
           />
@@ -192,7 +193,4 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(LabelingLoader)
+export default connect(mapStateToProps, mapDispatchToProps)(LabelingLoader)


### PR DESCRIPTION
# Description

Previously, if multiple images had to be labelled, user either had to manually change the URL to go back to the project page, or had to click the back button in the browser multiple times. This commit adds a __Home__ button which takes the user back to the respective project.

Fixes #261  (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

3 images were added and __Home__ button was pressed after labeling the third image.

**Test Configuration**:
The __Home__ button in the sidebar of the labeller
![labeller_home1](https://user-images.githubusercontent.com/9462834/73659214-bd391c80-46d0-11ea-8c24-ee76cfc67a04.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
