### PR TITLE
Replace deprecated React lifecycle methods

### DIFF
--- a/labellab-client/src/components/navbar/searchbar.js
+++ b/labellab-client/src/components/navbar/searchbar.js
@@ -15,7 +15,7 @@ class SearchProject extends Component {
       results: []
     }
   }
-  componentWillMount() {
+  componentDidMount() {
     this.resetComponent()
   }
   resetComponent = () =>

--- a/labellab-client/src/components/project/searchUser.js
+++ b/labellab-client/src/components/project/searchUser.js
@@ -15,7 +15,7 @@ class SearchUser extends Component {
       results: []
     }
   }
-  componentWillMount() {
+  componentDidMount() {
     this.resetComponent()
   }
   resetComponent = () =>
@@ -99,7 +99,4 @@ const mapActionToProps = dispatch => {
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapActionToProps
-)(SearchUser)
+export default connect(mapStateToProps, mapActionToProps)(SearchUser)


### PR DESCRIPTION
# Description

Deprecated React lifecycle method `componentWillMount` has been replaced with `componentDidMount`.

Fixes #268  (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Search bar was used to search for projects as well as other users.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
