### PR TITLE
Add image count label to the sidebar

### DIFF
--- a/labellab-client/src/components/project/sidebar.js
+++ b/labellab-client/src/components/project/sidebar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
-import { Menu, Button, Confirm } from 'semantic-ui-react'
+import { Menu, Button, Confirm, Label } from 'semantic-ui-react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import {
@@ -56,60 +56,67 @@ class ProjectSidebar extends Component {
     const { activeItem } = this.state
     return (
       <div className="sidebar-parent">
-        <div className="sidebar-menu-parent">
-          <Menu vertical size="large">
-            <Menu.Item
-              as={Link}
-              to={`/project/${project.projectId}/team`}
-              name="team"
-              active={activeItem === 'team'}
-              onClick={this.handleItemClick}
-            >
-              Project Team
-            </Menu.Item>
+        {project.images ? (
+          <div>
+            <div className="sidebar-menu-parent">
+              <Menu vertical size="large">
+                <Menu.Item
+                  as={Link}
+                  to={`/project/${project.projectId}/team`}
+                  name="team"
+                  active={activeItem === 'team'}
+                  onClick={this.handleItemClick}
+                >
+                  Project Team
+                </Menu.Item>
 
-            <Menu.Item
-              as={Link}
-              to={`/project/${project.projectId}/images`}
-              name="images"
-              active={activeItem === 'images'}
-              onClick={this.handleItemClick}
-            >
-              Project Images
-            </Menu.Item>
+                <Menu.Item
+                  as={Link}
+                  to={`/project/${project.projectId}/images`}
+                  name="images"
+                  active={activeItem === 'images'}
+                  onClick={this.handleItemClick}
+                >
+                  Project Images
+                  <Label>{project.images.length}</Label>
+                </Menu.Item>
 
-            <Menu.Item
-              as={Link}
-              to={`/project/${project.projectId}/analytics`}
-              name="analytics"
-              active={activeItem === 'analytics'}
-              onClick={this.handleItemClick}
-            >
-              Project Analytics
-            </Menu.Item>
-            <Menu.Item
-              as={Link}
-              to={`/project/${project.projectId}/labels`}
-              name="labels"
-              active={activeItem === 'labels'}
-              onClick={this.handleItemClick}
-            >
-              Project Labels
-            </Menu.Item>
-          </Menu>
-        </div>
+                <Menu.Item
+                  as={Link}
+                  to={`/project/${project.projectId}/analytics`}
+                  name="analytics"
+                  active={activeItem === 'analytics'}
+                  onClick={this.handleItemClick}
+                >
+                  Project Analytics
+                </Menu.Item>
+                <Menu.Item
+                  as={Link}
+                  to={`/project/${project.projectId}/labels`}
+                  name="labels"
+                  active={activeItem === 'labels'}
+                  onClick={this.handleItemClick}
+                >
+                  Project Labels
+                </Menu.Item>
+              </Menu>
+            </div>
 
-        <Button
-          negative
-          className="delete-project-button"
-          onClick={this.handleOpen}
-          content="Delete Project"
-        />
-        <Confirm
-          open={this.state.open}
-          onCancel={this.handleClose}
-          onConfirm={this.handleDeleteProject}
-        />
+            <Button
+              negative
+              className="delete-project-button"
+              onClick={this.handleOpen}
+              content="Delete Project"
+            />
+            <Confirm
+              open={this.state.open}
+              onCancel={this.handleClose}
+              onConfirm={this.handleDeleteProject}
+            />
+          </div>
+        ) : (
+          <div />
+        )}
       </div>
     )
   }


### PR DESCRIPTION
# Description

These changes add a label to the sidebar which shows the number of images belonging to a particular project. This is helpful to the user in case the model which they are training needs a certain number of images.

Fixes #274  (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

A new project was created and the label's value was 0. Then 2 images were added and the label showed the proper value. After deleting an image, the count in the label was reduced to the correct value.

**Test Configuration**:
1. New project:
![counter](https://user-images.githubusercontent.com/9462834/74600202-db3b4f80-50c8-11ea-9e43-21f826e3570a.PNG)

2. After adding 2 images:
![counter2](https://user-images.githubusercontent.com/9462834/74600205-e2625d80-50c8-11ea-8839-752666bfdac7.PNG)

3. After deleting an image:
![counter3](https://user-images.githubusercontent.com/9462834/74600207-eb532f00-50c8-11ea-8777-99441032e787.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
