### PR TITLE
Add feedback on auth failure

### DIFF
--- a/labellab_mobile/lib/screen/login/login_screen.dart
+++ b/labellab_mobile/lib/screen/login/login_screen.dart
@@ -81,8 +81,11 @@ class _LoginScreenState extends State<LoginScreen> {
                           child: _isLoginIn
                               ? Text("Signing In...")
                               : Text("Sign In"),
-                          onPressed: () =>
-                              !_isLoginIn ? _onSubmit(context) : null,
+                          onPressed: !_isLoginIn
+                              ? () {
+                                  _onSubmit(context);
+                                }
+                              : null,
                         ),
                       ),
                     ],

--- a/labellab_mobile/lib/screen/login/login_screen.dart
+++ b/labellab_mobile/lib/screen/login/login_screen.dart
@@ -69,18 +69,21 @@ class _LoginScreenState extends State<LoginScreen> {
                       SizedBox(
                         height: 16,
                       ),
-                      RaisedButton(
-                        elevation: 0,
-                        color: Theme.of(context).accentColor,
-                        colorBrightness: Brightness.dark,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
+                      Builder(
+                        builder: (context) => RaisedButton(
+                          elevation: 0,
+                          color: Theme.of(context).accentColor,
+                          colorBrightness: Brightness.dark,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          padding: EdgeInsets.symmetric(vertical: 16.0),
+                          child: _isLoginIn
+                              ? Text("Signing In...")
+                              : Text("Sign In"),
+                          onPressed: () =>
+                              !_isLoginIn ? _onSubmit(context) : null,
                         ),
-                        padding: EdgeInsets.symmetric(vertical: 16.0),
-                        child: _isLoginIn
-                            ? Text("Signing In...")
-                            : Text("Sign In"),
-                        onPressed: _isLoginIn ? null : _onSubmit,
                       ),
                     ],
                   ),
@@ -89,14 +92,19 @@ class _LoginScreenState extends State<LoginScreen> {
                   padding: const EdgeInsets.symmetric(vertical: 16.0),
                   child: Center(child: Text("or")),
                 ),
-                SignInButton(
-                  Buttons.GoogleDark,
-                  onPressed: () => !_isLoginIn ? _signInWithGoogle() : null,
+                Builder(
+                  builder: (context) => SignInButton(
+                    Buttons.GoogleDark,
+                    onPressed: () =>
+                        !_isLoginIn ? _signInWithGoogle(context) : null,
+                  ),
                 ),
-                SignInButton(
-                  Buttons.GitHub,
-                  onPressed: () =>
-                      !_isLoginIn ? _signInWithGithub(context) : null,
+                Builder(
+                  builder: (context) => SignInButton(
+                    Buttons.GitHub,
+                    onPressed: () =>
+                        !_isLoginIn ? _signInWithGithub(context) : null,
+                  ),
                 ),
                 SizedBox(
                   height: 16,
@@ -131,7 +139,7 @@ class _LoginScreenState extends State<LoginScreen> {
     return null;
   }
 
-  void _onSubmit() {
+  void _onSubmit(BuildContext context) {
     if (_key.currentState.validate()) {
       _key.currentState.save();
 
@@ -151,14 +159,12 @@ class _LoginScreenState extends State<LoginScreen> {
           _isLoginIn = false;
         });
         print(err.toString());
-        // Scaffold.of(context).showSnackBar(SnackBar(
-        //   content: Text("Sign in failed!"),
-        // ));
+        _showAuthFailSnackbar(context);
       });
     }
   }
 
-  void _signInWithGoogle() {
+  void _signInWithGoogle(BuildContext context) {
     setState(() {
       _isLoginIn = true;
     });
@@ -175,9 +181,7 @@ class _LoginScreenState extends State<LoginScreen> {
         _isLoginIn = false;
       });
       print(err.toString());
-      // Scaffold.of(context).showSnackBar(SnackBar(
-      //   content: Text("Sign in failed!"),
-      // ));
+      _showAuthFailSnackbar(context);
     });
   }
 
@@ -207,11 +211,19 @@ class _LoginScreenState extends State<LoginScreen> {
         setState(() {
           _isLoginIn = false;
         });
+        _showAuthFailSnackbar(context);
       }
     });
   }
 
   void _onCreateAccount() {
     Application.router.navigateTo(context, "/signup");
+  }
+
+  void _showAuthFailSnackbar(BuildContext context) {
+    Scaffold.of(context).showSnackBar(SnackBar(
+      content: Text("Sign in failed"),
+      backgroundColor: Colors.redAccent,
+    ));
   }
 }

--- a/labellab_mobile/lib/screen/sign_up/sign_up_screen.dart
+++ b/labellab_mobile/lib/screen/sign_up/sign_up_screen.dart
@@ -98,18 +98,21 @@ class _SignUpScreenState extends State<SignUpScreen> {
                       SizedBox(
                         height: 16,
                       ),
-                      RaisedButton(
-                        elevation: 0,
-                        color: Theme.of(context).accentColor,
-                        colorBrightness: Brightness.dark,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
+                      Builder(
+                        builder: (context) => RaisedButton(
+                          elevation: 0,
+                          color: Theme.of(context).accentColor,
+                          colorBrightness: Brightness.dark,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          padding: EdgeInsets.symmetric(vertical: 16.0),
+                          child: _isRegistering
+                              ? Text("Signnig Up")
+                              : Text("Sign Up"),
+                          onPressed: () =>
+                              !_isRegistering ? _onSubmit(context) : null,
                         ),
-                        padding: EdgeInsets.symmetric(vertical: 16.0),
-                        child: _isRegistering
-                            ? Text("Signnig Up")
-                            : Text("Sign Up"),
-                        onPressed: _isRegistering ? null : _onSubmit,
                       ),
                     ],
                   ),
@@ -173,7 +176,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
     return null;
   }
 
-  void _onSubmit() {
+  void _onSubmit(BuildContext context) {
     _key.currentState.save();
     if (_key.currentState.validate()) {
       setState(() {
@@ -193,9 +196,10 @@ class _SignUpScreenState extends State<SignUpScreen> {
           _isRegistering = false;
         });
         print(err.toString());
-        // Scaffold.of(context).showSnackBar(SnackBar(
-        //   content: Text("Sign in failed!"),
-        // ));
+        Scaffold.of(context).showSnackBar(SnackBar(
+          content: Text("Sign in failed"),
+          backgroundColor: Colors.redAccent,
+        ));
       });
     }
   }

--- a/labellab_mobile/lib/screen/sign_up/sign_up_screen.dart
+++ b/labellab_mobile/lib/screen/sign_up/sign_up_screen.dart
@@ -110,8 +110,11 @@ class _SignUpScreenState extends State<SignUpScreen> {
                           child: _isRegistering
                               ? Text("Signnig Up")
                               : Text("Sign Up"),
-                          onPressed: () =>
-                              !_isRegistering ? _onSubmit(context) : null,
+                          onPressed: !_isRegistering
+                              ? () {
+                                  _onSubmit(context);
+                                }
+                              : null,
                         ),
                       ),
                     ],


### PR DESCRIPTION
# Description

Currently, the app doesn't give any user feedback on authentication failure. This update shows a snack bar on login and registration failure. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# App Screenshots

![ss](https://user-images.githubusercontent.com/32796120/75270215-2fa8a280-5820-11ea-804d-9f0553463bff.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
