### PR TITLE
Update eslint configuration

### DIFF
--- a/labellab-client/.eslintrc.js
+++ b/labellab-client/.eslintrc.js
@@ -32,4 +32,4 @@ module.exports = {
         flowVersion: '0.53'
       }
     }
-  }
+}

--- a/labellab-client/package-lock.json
+++ b/labellab-client/package-lock.json
@@ -3142,29 +3142,16 @@
       }
     },
     "babel-eslint": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
-      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
-      "dev": true,
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.0.0",
         "@babel/traverse": "^7.0.0",
         "@babel/types": "^7.0.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
-      },
-      "dependencies": {
-        "eslint-scope": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-          "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        }
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
       }
     },
     "babel-extract-comments": {
@@ -5644,10 +5631,9 @@
       }
     },
     "dotenv": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
-      "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==",
-      "dev": true
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -6350,9 +6336,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
     },
     "espree": {
       "version": "6.1.2",
@@ -7139,12 +7125,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -8881,7 +8861,7 @@
               "optional": true
             },
             "yallist": {
-              "version": "3.0.3",
+              "version": "3.1.1",
               "bundled": true,
               "optional": true
             }
@@ -12433,86 +12413,6 @@
         "react-router": "5.0.1",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
-      }
-    },
-    "react-scripts": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.3.0.tgz",
-      "integrity": "sha512-hzPc6bxCc9GnsspWqk494c2Gpd0dRbk/C8q76BNQIENi9GMwoxFljOEcZoZcpFpJgQ45alxFR6QaLt+51qie7g==",
-      "requires": {
-        "@babel/core": "7.7.4",
-        "@svgr/webpack": "4.3.3",
-        "@typescript-eslint/eslint-plugin": "^2.8.0",
-        "@typescript-eslint/parser": "^2.8.0",
-        "babel-eslint": "10.0.3",
-        "babel-jest": "^24.9.0",
-        "babel-loader": "8.0.6",
-        "babel-plugin-named-asset-import": "^0.3.5",
-        "babel-preset-react-app": "^9.1.0",
-        "camelcase": "^5.3.1",
-        "case-sensitive-paths-webpack-plugin": "2.2.0",
-        "css-loader": "3.2.0",
-        "dotenv": "8.2.0",
-        "dotenv-expand": "5.1.0",
-        "eslint": "^6.6.0",
-        "eslint-config-react-app": "^5.1.0",
-        "eslint-loader": "3.0.2",
-        "eslint-plugin-flowtype": "3.13.0",
-        "eslint-plugin-import": "2.18.2",
-        "eslint-plugin-jsx-a11y": "6.2.3",
-        "eslint-plugin-react": "7.16.0",
-        "eslint-plugin-react-hooks": "^1.6.1",
-        "file-loader": "4.3.0",
-        "fs-extra": "^8.1.0",
-        "fsevents": "2.1.2",
-        "html-webpack-plugin": "4.0.0-beta.5",
-        "identity-obj-proxy": "3.0.0",
-        "jest": "24.9.0",
-        "jest-environment-jsdom-fourteen": "0.1.0",
-        "jest-resolve": "24.9.0",
-        "jest-watch-typeahead": "0.4.2",
-        "mini-css-extract-plugin": "0.8.0",
-        "optimize-css-assets-webpack-plugin": "5.0.3",
-        "pnp-webpack-plugin": "1.5.0",
-        "postcss-flexbugs-fixes": "4.1.0",
-        "postcss-loader": "3.0.0",
-        "postcss-normalize": "8.0.1",
-        "postcss-preset-env": "6.7.0",
-        "postcss-safe-parser": "4.0.1",
-        "react-app-polyfill": "^1.0.5",
-        "react-dev-utils": "^10.0.0",
-        "resolve": "1.12.2",
-        "resolve-url-loader": "3.1.1",
-        "sass-loader": "8.0.0",
-        "semver": "6.3.0",
-        "style-loader": "1.0.0",
-        "terser-webpack-plugin": "2.2.1",
-        "ts-pnp": "1.1.5",
-        "url-loader": "2.3.0",
-        "webpack": "4.41.2",
-        "webpack-dev-server": "3.9.0",
-        "webpack-manifest-plugin": "2.2.0",
-        "workbox-webpack-plugin": "4.3.1"
-      },
-      "dependencies": {
-        "babel-eslint": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
-          "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.0.0",
-            "@babel/traverse": "^7.0.0",
-            "@babel/types": "^7.0.0",
-            "eslint-visitor-keys": "^1.0.0",
-            "resolve": "^1.12.0"
-          }
-        },
-        "dotenv": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-          "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
-        }
       }
     },
     "react-side-effect": {

--- a/labellab-client/package.json
+++ b/labellab-client/package.json
@@ -90,9 +90,6 @@
     "lint": "eslint src/ --fix",
     "format": "prettier --write \"src/**/*.{js,jsx,json}\""
   },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
   "browserslist": {
     "production": [
       ">0.2%",
@@ -106,7 +103,7 @@
     ]
   },
   "devDependencies": {
-    "babel-eslint": "^10.0.1",
+    "babel-eslint": "^10.0.3",
     "dotenv": "^8.0.0",
     "eslint-config-prettier": "^4.3.0",
     "eslint-plugin-prettier": "^3.1.0"


### PR DESCRIPTION
# Description
Fixed conflicting eslint configurations.

Specifying `eslintConfig` in `package.json` is unnecessary (see below snippet) because existing eslint configuration `.eslintrc.js` already exists and is automatically loaded. 
```
  "eslintConfig": {
    "extends": "react-app"
  },
```

The `.eslintrc.js` file already extends the above configuration `react-app` so it's safe to delete these lines. (see below snippet)
```
    extends: [
      'eslint:recommended',
      'plugin:react/recommended',
      'react-app',  <--
      'plugin:prettier/recommended',
      'prettier/react'
    ],
```
Keeping these can make conflicts and prevent the client from starting because `.eslintrc.js` has custom overrides that might be different from rules in `react-app`. I think this is some leftovers when rejecting the client from CRA.
