### PR TITLE
fix the prop types warnings coming due to missing eslint configuration

### DIFF
--- a/labellab-client/.eslintrc.js
+++ b/labellab-client/.eslintrc.js
@@ -1,35 +1,36 @@
 module.exports = {
-    env: {
-      browser: true,
-      commonjs: true,
-      es6: true
-    },
-    extends: [
-      'eslint:recommended',
-      'plugin:react/recommended',
-      'react-app',
-      'plugin:prettier/recommended',
-      'prettier/react'
+  env: {
+    browser: true,
+    commonjs: true,
+    es6: true
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'react-app',
+    'plugin:prettier/recommended',
+    'prettier/react'
+  ],
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module'
+  },
+  rules: {
+    'no-unused-vars': [
+      'off',
+      { vars: 'all', args: 'after-used', ignoreRestSiblings: false }
     ],
-    parser: 'babel-eslint',
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module'
-    },
-    rules: {
-      'no-unused-vars': [
-        'off',
-        { vars: 'all', args: 'after-used', ignoreRestSiblings: false }
-      ],
-      'no-console': 'off',
-      'prettier/prettier': ['warn', { semi: false, singleQuote: true }]
-    },
-    settings: {
-      react: {
-        createClass: 'createReactClass',
-        pragma: 'React',
-        version: 'detect',
-        flowVersion: '0.53'
-      }
+    'no-console': 'off',
+    'prettier/prettier': ['warn', { semi: false, singleQuote: true }],
+    "react/prop-types": 0
+  },
+  settings: {
+    react: {
+      createClass: 'createReactClass',
+      pragma: 'React',
+      version: 'detect',
+      flowVersion: '0.53'
     }
+  }
 }

--- a/labellab-client/src/components/labeller/CalcBoundsHOC.js
+++ b/labellab-client/src/components/labeller/CalcBoundsHOC.js
@@ -25,7 +25,8 @@ export function withBounds(Comp) {
     }
   }
 
-  return forwardRef((props, ref) => (
-    <CalcBoundsLayer {...props} forwardedRef={ref} />
-  ))
+  function exp(props, ref){
+    return <CalcBoundsLayer {...props} forwardedRef={ref} />
+  }
+  return forwardRef(exp)
 }

--- a/labellab-client/src/components/labeller/Canvas.js
+++ b/labellab-client/src/components/labeller/Canvas.js
@@ -52,7 +52,7 @@ class Canvas extends Component {
   handleChange(eventType, { point, pos, figure, points }) {
     const { onChange, unfinishedFigure } = this.props
     const drawing = !!unfinishedFigure
-
+    const f = null
     switch (eventType) {
       case 'add':
         if (drawing) {
@@ -76,7 +76,7 @@ class Canvas extends Component {
         break
 
       case 'end':
-        const f = unfinishedFigure
+        f = unfinishedFigure
         onChange('new', f)
         break
 
@@ -157,14 +157,14 @@ class Canvas extends Component {
 
     const unfinishedDrawingDOM = drawing
       ? this.renderFigure(unfinishedFigure, {
-          finished: false,
-          editing: false,
-          interactive: false,
-          color: colorMapping[unfinishedFigure.color],
-          onChange: this.handleChange,
-          calcDistance,
-          newPoint: cursorPos
-        })
+        finished: false,
+        editing: false,
+        interactive: false,
+        color: colorMapping[unfinishedFigure.color],
+        onChange: this.handleChange,
+        calcDistance,
+        newPoint: cursorPos
+      })
       : null
 
     const getColor = f =>


### PR DESCRIPTION
# Description
fix the prop types warnings coming due to missing eslint configuration and fix other errors in the labeller components. After fixing the linting issues I found other errors were coming in the CalcBoundsHOC.js and the Canvas.js. Now mainly prettier warnings are comming.
Fixes #310 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Before fixing the issues:
<img width="1440" alt="Screenshot 2020-03-01 at 8 42 35 PM" src="https://user-images.githubusercontent.com/43586052/75628411-ac5fc600-5bfe-11ea-9e4c-611e9da57eb6.png">
<img width="1440" alt="Screenshot 2020-03-01 at 8 44 45 PM" src="https://user-images.githubusercontent.com/43586052/75628413-aff34d00-5bfe-11ea-9da4-bd9c3a061acb.png">
After fixing the issues:
<img width="1440" alt="Screenshot 2020-03-01 at 8 54 33 PM" src="https://user-images.githubusercontent.com/43586052/75628427-e16c1880-5bfe-11ea-98e6-0e1718c07a6f.png">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
