### PR TITLE
Fix missing key prop

### DIFF
--- a/labellab-client/src/components/profile/index.js
+++ b/labellab-client/src/components/profile/index.js
@@ -144,7 +144,7 @@ class Profile extends Component {
                       <Dropdown.Menu>
                         {
                           this.props.projects.map(project =>
-                            <Dropdown.Item as={Link} to={'/project/' + project._id + '/analytics'}>
+                            <Dropdown.Item key={project._id} as={Link} to={'/project/' + project._id + '/analytics'}>
                               {project.projectName}
                             </Dropdown.Item>
                           )

--- a/labellab-client/src/components/project/label/index.js
+++ b/labellab-client/src/components/project/label/index.js
@@ -109,6 +109,7 @@ class LabelIndex extends Component {
             <Table.Body>
               {labels.map((label, index) => (
                 <LabelItem
+                  key={label._id}
                   index={index}
                   label={label}
                   options={options}


### PR DESCRIPTION
# Description
I've added unique key props for iterators where they were missing. This should remove errors (see issue #328) which occurred in compile-time.

Fixes #328 

It seemed that for some people this error didn't occur. However I'd suggest that we add these props anyways, so that React can perform DOM manipulations faster and accurately. (You can skip these warnings in `.eslintrc` by adding a custom rule too)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)