### PR TITLE
Add reset changes button

### DIFF
--- a/labellab_mobile/lib/screen/project/edit_image/project_edit_image_bloc.dart
+++ b/labellab_mobile/lib/screen/project/edit_image/project_edit_image_bloc.dart
@@ -5,6 +5,7 @@ import 'package:labellab_mobile/screen/project/edit_image/project_edit_image_sta
 import 'package:logger/logger.dart';
 
 class ProjectEditImageBloc {
+  File _original;
   File _image;
   bool _isLoading = false;
 
@@ -19,12 +20,18 @@ class ProjectEditImageBloc {
     imagePath = imagePath.replaceAll(new RegExp('#'), '/');
     Logger().i(imagePath);
     _image = File(imagePath);
+    _original = _image;
     _isLoading = false;
     _stateController.add(ProjectEditImageState.success(image: _image));
   }
 
   void cropImage(File croppedFile) {
     _image = croppedFile;
+    _stateController.add(ProjectEditImageState.edited(image: _image));
+  }
+
+  void revertImage() {
+    _image = _original;
     _stateController.add(ProjectEditImageState.success(image: _image));
   }
 

--- a/labellab_mobile/lib/screen/project/edit_image/project_edit_image_screen.dart
+++ b/labellab_mobile/lib/screen/project/edit_image/project_edit_image_screen.dart
@@ -61,16 +61,30 @@ class ProjectEditImageScreen extends StatelessWidget {
               height: 64,
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: <Widget>[
-                  LabelIconButton(Icons.crop, "Crop", onTap: () {
-                    _showImageCrop(context, _state.image);
-                  }),
-                  LabelIconButton(
-                    Icons.photo_size_select_large,
-                    "Resize",
-                    onTap: _showImageResize,
-                  ),
-                ],
+                children: _state.isEdited
+                    ? <Widget>[
+                        LabelIconButton(Icons.undo, "Reset", onTap: () {
+                          _revertEdits(context);
+                        }),
+                        LabelIconButton(Icons.crop, "Crop", onTap: () {
+                          _showImageCrop(context, _state.image);
+                        }),
+                        LabelIconButton(
+                          Icons.photo_size_select_large,
+                          "Resize",
+                          onTap: _showImageResize,
+                        ),
+                      ]
+                    : <Widget>[
+                        LabelIconButton(Icons.crop, "Crop", onTap: () {
+                          _showImageCrop(context, _state.image);
+                        }),
+                        LabelIconButton(
+                          Icons.photo_size_select_large,
+                          "Resize",
+                          onTap: _showImageResize,
+                        ),
+                      ],
               ),
             ),
           )
@@ -117,4 +131,8 @@ class ProjectEditImageScreen extends StatelessWidget {
   }
 
   void _showImageResize() {}
+
+  void _revertEdits(BuildContext context) {
+    Provider.of<ProjectEditImageBloc>(context).revertImage();
+  }
 }

--- a/labellab_mobile/lib/screen/project/edit_image/project_edit_image_state.dart
+++ b/labellab_mobile/lib/screen/project/edit_image/project_edit_image_state.dart
@@ -1,7 +1,8 @@
 import 'dart:io';
 
 class ProjectEditImageState {
-  bool isLoading;
+  bool isLoading = false;
+  bool isEdited = false;
   String error;
   File image;
 
@@ -9,11 +10,11 @@ class ProjectEditImageState {
     isLoading = true;
   }
 
-  ProjectEditImageState.error(this.error, {this.image}) {
-    isLoading = false;
-  }
+  ProjectEditImageState.error(this.error, {this.image});
 
-  ProjectEditImageState.success({this.image}) {
-    isLoading = false;
+  ProjectEditImageState.success({this.image});
+
+  ProjectEditImageState.edited({this.image}) {
+    isEdited = true;
   }
 }


### PR DESCRIPTION
# Description

Added a button to revert the edits and reset the image to its original state. 

Fixes #334 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots

![Screenshot_1583787776](https://user-images.githubusercontent.com/32796120/76257917-998d6700-6278-11ea-81f3-d38c86211037.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
