### PR TITLE
Add labels dropdown and labels count on the labels in each image

### DIFF
--- a/labellab-client/src/components/project/css/index.css
+++ b/labellab-client/src/components/project/css/index.css
@@ -1,6 +1,7 @@
 .project-main {
   display: flex;
 }
+
 .project-non-side-section {
   width: 100%;
   margin-right: unset !important;
@@ -18,4 +19,12 @@
     margin-right: unset !important;
     min-height: 50%;
   }
+}
+
+.project-non-side-section {
+    width: 75%;
+}
+
+.labelDropdown {
+    margin-left: 25vw;
 }

--- a/labellab-client/src/components/project/images.js
+++ b/labellab-client/src/components/project/images.js
@@ -8,8 +8,9 @@ import {
   Form,
   Dimmer,
   Loader,
+  Icon,
   Checkbox,
-  Icon
+  Dropdown
 } from 'semantic-ui-react'
 import { AutoSizer, List } from 'react-virtualized'
 import Lightbox from 'react-image-lightbox'
@@ -171,7 +172,7 @@ class ImagesIndex extends Component {
                 nextSrc={imageUrls[(photoIndex + 1) % imageUrls.length]}
                 prevSrc={
                   imageUrls[
-                    (photoIndex + imageUrls.length - 1) % imageUrls.length
+                  (photoIndex + imageUrls.length - 1) % imageUrls.length
                   ]
                 }
                 onCloseRequest={() => this.setState({ isOpen: false })}
@@ -296,55 +297,70 @@ const Row = ({
   selected,
   isLast,
 }) => (
-  <Table.Row
-    style={{
-      ...style,
-      display: 'flex',
-      borderBottom: isLast ? '1px solid rgba(34,36,38,.1)' : '',
-    }}
-  >
-    <Table.Cell width={1}>
-      {imageId + 1}
-      {image.labelled ? <Icon name="checkmark green"></Icon> : null}
-    </Table.Cell>
-    <Table.Cell width={1}>
-      <Checkbox
-        onClick={() => {
-          onSelect(image._id)
-        }}
-        checked={selected}
-      />
-    </Table.Cell>
-    <Table.Cell width={11}>
-      <a
-        href={
-          process.env.REACT_APP_HOST +
-          ':' +
-          process.env.REACT_APP_SERVER_PORT +
-          `/static/uploads/${image.imageUrl}?${Date.now()}`
-        }
-      >
-        {image.imageName}
-      </a>
-    </Table.Cell>
-    <Table.Cell width={3}>
-      <div>
-        <Link to={`/labeller/${projectId}/${image._id}`}>
-          <Button icon="pencil" label="Edit" size="tiny" />
-        </Link>
-        <Button
-          icon="trash"
-          label="Delete"
-          size="tiny"
-          onClick={async () => {
-            await onSelect(image._id)
-            onDelete()
+    <Table.Row
+      style={{
+        ...style,
+        display: 'flex',
+        borderBottom: isLast ? '1px solid rgba(34,36,38,.1)' : '',
+      }}
+    >
+      <Table.Cell width={1}>
+        {imageId + 1}
+        {image.labelled ? <Icon name="checkmark green"></Icon> : null}
+      </Table.Cell>
+      <Table.Cell width={1}>
+        <Checkbox
+          onClick={() => {
+            onSelect(image._id)
           }}
+          checked={selected}
         />
-      </div>
-    </Table.Cell>
-  </Table.Row>
-)
+      </Table.Cell>
+      <Table.Cell width={11}>
+        <a
+          href={
+            process.env.REACT_APP_HOST +
+            ':' +
+            process.env.REACT_APP_SERVER_PORT +
+            `/static/uploads/${image.imageUrl}?${Date.now()}`
+          }
+        >
+          {image.imageName}
+        </a>
+        {image.labelled ? (
+          <span className="labelDropdown">
+            <Dropdown text="Labels">
+              <Dropdown.Menu>
+                {Object.keys(image.labelData).map((key, index) =>
+                  image.labelData[key].length !== 0 ?
+                    <Dropdown.Item
+                      text={key + '  ' + image.labelData[key].length}
+                      key={index} />
+                    : null
+                )}
+              </Dropdown.Menu>
+            </Dropdown>
+          </span>) : null
+        }
+      </Table.Cell>
+      <Table.Cell width={3}>
+        <div>
+          <Link to={`/labeller/${projectId}/${image._id}`}>
+            <Button icon="pencil" label="Edit" size="tiny" />
+          </Link>
+          <Button
+            icon="trash"
+            label="Delete"
+            size="tiny"
+            onClick={async () => {
+              await onSelect(image._id)
+              onDelete()
+            }}
+          />
+        </div>
+      </Table.Cell>
+    </Table.Row>
+  )
 
 const AutoSizedList = props => (
   <AutoSizer>


### PR DESCRIPTION
# Description
Add dropdown beside every image displaying the name of the label and the no of labels beside it. 
Fixes #306 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
<img width="933" alt="Screenshot 2020-03-11 at 6 15 32 PM" src="https://user-images.githubusercontent.com/43586052/76421980-84c0e880-63ca-11ea-9fe4-342b7ffce154.png">


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
