### PR TITLE
Cleanup environment variable: remove colon (React client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ First you need to create a `.env` file in both `labellab-server` folder and `lab
 
 For client-side `.env` file:
 ```
-REACT_APP_HOST=http://localhost:
+REACT_APP_HOST=http://localhost
 REACT_APP_SERVER_ENVIORNMENT=dev
 REACT_APP_SERVER_PORT=4000
 ```

--- a/labellab-client/src/components/labeller/index.js
+++ b/labellab-client/src/components/labeller/index.js
@@ -116,9 +116,7 @@ class LabelingLoader extends Component {
             labels={lab}
             labelData={(img && img.labelData) || {}}
             imageUrl={
-              process.env.REACT_APP_HOST +
-              process.env.REACT_APP_SERVER_PORT +
-              `/static/uploads/${image.imageUrl}?${Date.now()}`
+              `${process.env.REACT_APP_HOST}:${process.env.REACT_APP_SERVER_PORT}/static/uploads/${image.imageUrl}?${Date.now()}`
             }
             demo={false}
             {...props}

--- a/labellab-client/src/components/login/index.js
+++ b/labellab-client/src/components/login/index.js
@@ -188,9 +188,7 @@ class LoginIndex extends Component {
             <div className="login-icons">
               <a
                 href={
-                  process.env.REACT_APP_HOST +
-                  process.env.REACT_APP_SERVER_PORT +
-                  `/api/v1/auth/google`
+                  `${process.env.REACT_APP_HOST}:${process.env.REACT_APP_SERVER_PORT}/api/v1/auth/google`
                 }
               >
                 <Image src={googleIcon} />
@@ -199,9 +197,7 @@ class LoginIndex extends Component {
             <div className="login-icons">
               <a
                 href={
-                  process.env.REACT_APP_HOST +
-                  process.env.REACT_APP_SERVER_PORT +
-                  `/api/v1/auth/github`
+                  `${process.env.REACT_APP_HOST}:${process.env.REACT_APP_SERVER_PORT}/api/v1/auth/github`
                 }
               >
                 <Image src={githubIcon} />

--- a/labellab-client/src/components/project/images.js
+++ b/labellab-client/src/components/project/images.js
@@ -285,9 +285,7 @@ const Row = ({
     <Table.Cell style={columnStyles[1]}>
       <a
         href={
-          process.env.REACT_APP_HOST +
-          process.env.REACT_APP_SERVER_PORT +
-          `/static/uploads/${image.imageUrl}?${Date.now()}`
+          `${process.env.REACT_APP_HOST}:${process.env.REACT_APP_SERVER_PORT}/static/uploads/${image.imageUrl}?${Date.now()}`
         }
       >
         {image.imageName}

--- a/labellab-client/src/utils/FetchAPI.js
+++ b/labellab-client/src/utils/FetchAPI.js
@@ -5,9 +5,7 @@ import { TOKEN_TYPE } from '../constants/index'
 const FetchApi = (method, url, params, TokenValue) => {
   if (process.env.REACT_APP_SERVER_ENVIORNMENT === 'dev') {
     url =
-      process.env.REACT_APP_HOST +
-      process.env.REACT_APP_SERVER_PORT +
-      url
+    `${process.env.REACT_APP_HOST}:${process.env.REACT_APP_SERVER_PORT}${url}`
   }
   console.log(url)
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Removes colon from `REACT_APP_HOST` environment variable. Wherever it's used in the sources has been replaced them with correct formatting.

The reason for this PR is that colon shouldn't be part of that variable, and it can be mistakenly ignored by new contributors. (happend to me :smile:) Therefore I'd think this is a necessary change. 

## Type of change
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

All existing functionality has been manually tested and working.
