### PR TITLE
Feat: Show label count on images

### DIFF
--- a/labellab_mobile/lib/screen/project/detail/project_detail_screen.dart
+++ b/labellab_mobile/lib/screen/project/detail/project_detail_screen.dart
@@ -184,11 +184,40 @@ class ProjectDetailScreen extends StatelessWidget {
                       width: 64,
                       height: 64,
                       color: Colors.black12,
-                      child: Image(
-                        image: CachedNetworkImageProvider(
-                          image.imageUrl,
-                        ),
-                        fit: BoxFit.cover,
+                      child: Stack(
+                        fit: StackFit.expand,
+                        children: <Widget>[
+                          Image(
+                            image: CachedNetworkImageProvider(
+                              image.imageUrl,
+                            ),
+                            fit: BoxFit.cover,
+                          ),
+                          Container(
+                            decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                    begin: Alignment.topCenter,
+                                    end: Alignment.bottomCenter,
+                                    colors: [
+                                  Colors.black38,
+                                  Color.fromRGBO(255, 255, 255, 0)
+                                ])),
+                          ),
+                          Positioned(
+                            top: 8,
+                            right: 8,
+                            child: Text(
+                              image.labels != null
+                                  ? image.labels.length != 1
+                                      ? image.labels.length.toString() +
+                                          " Labels"
+                                      : "1 Label"
+                                  : "",
+                              style:
+                                  TextStyle(color: Colors.white, fontSize: 14),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   ),


### PR DESCRIPTION
# Description

As mentioned in the issue, by showing the label count on images users can manage the labeled images easily. 

Fixes #355 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots

![Screenshot_1584120513](https://user-images.githubusercontent.com/32796120/76645307-bd092800-657e-11ea-8a62-426c33188ee7.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
