### PR TITLE
Make image count decrease on image deletion

### DIFF
--- a/labellab-server/controller/image/imageControls.js
+++ b/labellab-server/controller/image/imageControls.js
@@ -240,7 +240,11 @@ exports.deleteImage = function(req, res) {
           )
           Project.findOneAndUpdate(
             { _id: image.project },
-            { $pull: { image: req.params.imageId } }
+            {
+              $pull: {
+                image: image._id
+              }
+            }
           ).exec(function(err, project) {
             if (err) {
               return res.status(400).send({


### PR DESCRIPTION
# Description

These changes configure the image deletion controller to update the list of images stored in the project when an image is deleted. This ensures that the __Total Images__ shown in the profile page is accurate.

Fixes #339  (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Uploaded 2 images and saw the count in the profile page. Deleted an image and the count on the profile page had decreased by 1.

**Test Configuration**:
1. Initial list of images:
![count](https://user-images.githubusercontent.com/9462834/76655074-7976e400-65a7-11ea-908c-f32530318701.PNG)

2. Initial image count:
![count2](https://user-images.githubusercontent.com/9462834/76655091-84ca0f80-65a7-11ea-87b2-d6d2e9c718b4.PNG)

3. Image count after deleting 1 image:
![count3](https://user-images.githubusercontent.com/9462834/76655103-8bf11d80-65a7-11ea-9079-90c089db1c97.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
