### PR TITLE
Add multiple images preview

### DIFF
--- a/labellab-client/package.json
+++ b/labellab-client/package.json
@@ -57,6 +57,7 @@
     "react-document-meta": "^3.0.0-beta.2",
     "react-dom": "^16.8.6",
     "react-hot-keys": "^1.2.2",
+    "react-image-lightbox": "^5.1.1",
     "react-leaflet": "^2.2.0",
     "react-leaflet-control": "^2.1.1",
     "react-loadable": "^5.5.0",

--- a/labellab-client/src/components/project/images.js
+++ b/labellab-client/src/components/project/images.js
@@ -12,6 +12,8 @@ import {
   Icon
 } from 'semantic-ui-react'
 import { AutoSizer, List } from 'react-virtualized'
+import Lightbox from 'react-image-lightbox';
+import 'react-image-lightbox/style.css'; 
 import { submitImage, deleteImage, fetchProject } from '../../actions/index'
 import './css/images.css'
 
@@ -26,7 +28,10 @@ class ImagesIndex extends Component {
       showform: false,
       format: '',
       maxSizeError: '',
-      selectedList: []
+      selectedList: [],
+      imageUrls:[],
+      photoIndex: 0,
+      isOpen: false,
     }
   }
   handleImageChange = e => {
@@ -39,15 +44,18 @@ class ImagesIndex extends Component {
           images: [...prevState.images, reader.result],
           file: file,
           format: file.type,
-          imageNames: [...prevState.imageNames, file.name]
+          imageNames: [...prevState.imageNames, file.name],
+          imageUrls:[...prevState.imageUrls, URL.createObjectURL(file)]
         }))
       }
       reader.readAsDataURL(file)
     })
     this.setState({
-      showform: !this.state.showform
+      showform: !this.state.showform,
+      isOpen: true
     })
   }
+  
   handleSubmit = e => {
     e.preventDefault()
     const { project, fetchProject, submitImage } = this.props
@@ -107,13 +115,17 @@ class ImagesIndex extends Component {
       imageNames: [],
       showform: !this.state.showform,
       format: '',
-      maxSizeError: ''
+      maxSizeError: '',
+      imageUrls:[],
+      photoIndex: 0,
+      isOpen: false,
     })
   }
 
   render() {
-    const { imageActions, project } = this.props
-    const { showform, imageName } = this.state
+    const { imageActions, project } = this.props;
+    const { showform, imageName, imageUrls } = this.state;
+    const { photoIndex, isOpen } = this.state;
     return (
       <div>
         {imageActions.isdeleting ? (
@@ -136,7 +148,6 @@ class ImagesIndex extends Component {
             Add Image
           </label>
         </div>
-
         {showform ? (
           <Form
             className="file-submit-form"
@@ -154,12 +165,34 @@ class ImagesIndex extends Component {
                 />
               </Form.Field>
             )}
-
+            {
+              imageUrls && isOpen ?
+              <Lightbox
+                mainSrc={imageUrls[photoIndex]}
+                nextSrc={imageUrls[(photoIndex + 1) % imageUrls.length]}
+                prevSrc={imageUrls[(photoIndex + imageUrls.length - 1) % imageUrls.length]}
+                onCloseRequest={() => this.setState({ isOpen: false })}
+                onMovePrevRequest={() =>
+                  this.setState({
+                    photoIndex: (photoIndex + imageUrls.length - 1) % imageUrls.length,
+                  })
+                }
+                onMoveNextRequest={() =>
+                  this.setState({
+                    photoIndex: (photoIndex + 1) % imageUrls.length,
+                  })
+                }
+          />:
+              null
+            }
             <Button loading={imageActions.isposting} type="submit">
               Submit
             </Button>
             <Button onClick={this.removeImage} type="delete">
               Cancel
+            </Button>
+            <Button onClick={()=>this.setState({isOpen:true})}>
+              View
             </Button>
             {this.state.maxSizeError ? (
               <div className="max-size-error">
@@ -285,7 +318,9 @@ const Row = ({
     <Table.Cell style={columnStyles[1]}>
       <a
         href={
-          `${process.env.REACT_APP_HOST}:${process.env.REACT_APP_SERVER_PORT}/static/uploads/${image.imageUrl}?${Date.now()}`
+          process.env.REACT_APP_HOST + ':' +
+          process.env.REACT_APP_SERVER_PORT +
+          `/static/uploads/${image.imageUrl}?${Date.now()}`
         }
       >
         {image.imageName}


### PR DESCRIPTION
# Description

Added a feature to preview multiple images at once before uploading them.

Fixes #326 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<img width="1440" alt="Screenshot 2020-03-19 at 4 05 15 AM" src="https://user-images.githubusercontent.com/43586052/77014145-a35d4b80-6997-11ea-9091-f98a0ca4c557.png">
<img width="488" alt="Screenshot 2020-03-19 at 4 05 32 AM" src="https://user-images.githubusercontent.com/43586052/77014161-a9ebc300-6997-11ea-9fe2-c1aeb97da97b.png">


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
