### PR TITLE
Feat: Implement multiple images delete

### DIFF
--- a/labellab_mobile/lib/data/remote/labellab_api.dart
+++ b/labellab_mobile/lib/data/remote/labellab_api.dart
@@ -32,13 +32,17 @@ abstract class LabelLabAPI {
   Future<ApiResponse> updateProject(String token, Project project);
   Future<ApiResponse> deleteProject(String token, String id);
   Future<ApiResponse> addMember(String token, String projectId, String email);
-  Future<ApiResponse> removeMember(String token, String projectId, String email);
+  Future<ApiResponse> removeMember(
+      String token, String projectId, String email);
 
   // Image
-  Future<ApiResponse> uploadImage(String token, String projectId, UploadImage image);
+  Future<ApiResponse> uploadImage(
+      String token, String projectId, UploadImage image);
   Future<Image> getImage(String token, String imageId);
-  Future<ApiResponse> updateImage(String token, Image image, List<LabelSelection> selections);
+  Future<ApiResponse> updateImage(
+      String token, Image image, List<LabelSelection> selections);
   Future<ApiResponse> deleteImage(String token, String imageId);
+  Future<ApiResponse> deleteImages(String token, List<String> imageIds);
 
   // Label
   Future<List<Label>> getLabels(String token, String projectId);

--- a/labellab_mobile/lib/data/remote/labellab_api_impl.dart
+++ b/labellab_mobile/lib/data/remote/labellab_api_impl.dart
@@ -335,6 +335,20 @@ class LabelLabAPIImpl extends LabelLabAPI {
   }
 
   @override
+  Future<ApiResponse> deleteImages(String token, List<String> imageIds) {
+    final data = {"images": imageIds};
+    Options options = Options(
+      headers: {HttpHeaders.authorizationHeader: "Bearer " + token},
+    );
+    return _dio
+        .delete(API_URL + ENDPOINT_IMAGE + "/delete",
+            options: options, data: data)
+        .then((response) {
+      return ApiResponse(response.data);
+    });
+  }
+
+  @override
   Future<List<Label>> getLabels(String token, String projectId) {
     Options options = Options(
       headers: {HttpHeaders.authorizationHeader: "Bearer " + token},

--- a/labellab_mobile/lib/data/repository.dart
+++ b/labellab_mobile/lib/data/repository.dart
@@ -175,6 +175,11 @@ class Repository {
     return _api.deleteImage(accessToken, imageId);
   }
 
+  Future<ApiResponse> deleteImages(List<String> imageIds) {
+    if (accessToken == null) return Future(null);
+    return _api.deleteImages(accessToken, imageIds);
+  }
+
   // Label
   Future<ApiResponse> createLabel(String projectId, Label label) {
     if (accessToken == null) return Future(null);

--- a/labellab_mobile/lib/screen/project/detail/project_detail_bloc.dart
+++ b/labellab_mobile/lib/screen/project/detail/project_detail_bloc.dart
@@ -12,6 +12,7 @@ class ProjectDetailBloc {
 
   Project _project;
   bool _isLoading = false;
+  List<String> _selectedImages = [];
 
   ProjectDetailBloc(this.projectId) {
     _loadProject();
@@ -37,6 +38,42 @@ class ProjectDetailBloc {
     });
   }
 
+  // Used for initial selection of image
+  void selectImage(String id) {
+    _selectedImages.add(id);
+    _setState(ProjectDetailState.multiSelect(_project,
+        selectedImages: _selectedImages));
+  }
+
+  // Used to switch selection state
+  void switchSelection(String id) {
+    _selectedImages.contains(id)
+        ? _selectedImages.remove(id)
+        : _selectedImages.add(id);
+    _setState(ProjectDetailState.multiSelect(_project,
+        selectedImages: _selectedImages));
+  }
+
+  // Used to select all images
+  void selectAllImages() {
+    _selectedImages = _project.images.map((image) => image.id).toList();
+    _setState(ProjectDetailState.multiSelect(_project,
+        selectedImages: _selectedImages));
+  }
+
+  // Used to delete selected images
+  void deleteSelected() {
+    _repository.deleteImages(_selectedImages).then((_) {
+      refresh();
+    });
+  }
+
+  // Used to cancel current selection
+  void cancelSelection() {
+    _selectedImages = [];
+    _setState(ProjectDetailState.success(_project));
+  }
+
   // Project stream
   StreamController<ProjectDetailState> _stateController =
       StreamController<ProjectDetailState>();
@@ -44,6 +81,7 @@ class ProjectDetailBloc {
   Stream<ProjectDetailState> get state => _stateController.stream;
 
   void _loadProject() {
+    _selectedImages = [];
     if (_isLoading) return;
     _isLoading = true;
     _setState(ProjectDetailState.loading(project: _project));

--- a/labellab_mobile/lib/screen/project/detail/project_detail_screen.dart
+++ b/labellab_mobile/lib/screen/project/detail/project_detail_screen.dart
@@ -63,15 +63,35 @@ class ProjectDetailScreen extends StatelessWidget {
                                 "Images",
                                 style: Theme.of(context).textTheme.title,
                               ),
-                              _state.project.images.length > 8
-                                  ? FlatButton(
-                                      child: Text("More"),
-                                      onPressed: () => _gotoMoreImagesScreen(
-                                        context,
-                                        _state.project.id,
-                                      ),
-                                    )
-                                  : Container(),
+                              Container(
+                                child: Row(
+                                  children: <Widget>[
+                                    _state.project.images.length > 8
+                                        ? FlatButton(
+                                            child: Text("More"),
+                                            onPressed: () =>
+                                                _gotoMoreImagesScreen(
+                                              context,
+                                              _state.project.id,
+                                            ),
+                                          )
+                                        : Container(),
+                                    _state.isSelecting
+                                        ? PopupMenuButton<int>(
+                                            child: Container(
+                                              child:
+                                                  Icon(Icons.arrow_drop_down),
+                                            ),
+                                            onSelected: (int index) =>
+                                                _onImageAction(context, index),
+                                            itemBuilder:
+                                                (BuildContext context) =>
+                                                    _buildImageActions(context),
+                                          )
+                                        : Container()
+                                  ],
+                                ),
+                              ),
                             ],
                           ),
                         ),
@@ -80,7 +100,11 @@ class ProjectDetailScreen extends StatelessWidget {
                   : SliverFillRemaining(),
               _state.project != null && _state.project.images != null
                   ? _buildImages(
-                      context, _state.project.id, _state.project.images)
+                      context,
+                      _state.project.id,
+                      _state.project.images,
+                      _state.isSelecting,
+                      _state.selectedImages)
                   : SliverFillRemaining(),
               _state.project != null && _state.project.labels != null
                   ? _buildLabels(
@@ -168,7 +192,11 @@ class ProjectDetailScreen extends StatelessWidget {
   }
 
   Widget _buildImages(
-      BuildContext context, String projectId, List<LabelLab.Image> images) {
+      BuildContext context,
+      String projectId,
+      List<LabelLab.Image> images,
+      bool isSelecting,
+      List<String> selectedImages) {
     return images.length > 0
         ? SliverPadding(
             padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -217,11 +245,31 @@ class ProjectDetailScreen extends StatelessWidget {
                                   TextStyle(color: Colors.white, fontSize: 14),
                             ),
                           ),
+                          selectedImages.contains(image.id)
+                              ? Container(
+                                  decoration: BoxDecoration(
+                                    color: Theme.of(context)
+                                        .accentColor
+                                        .withOpacity(0.8),
+                                  ),
+                                  child: Center(
+                                    child: Icon(
+                                      Icons.done,
+                                      color: Colors.white,
+                                    ),
+                                  ),
+                                )
+                              : Container()
                         ],
                       ),
                     ),
                   ),
-                  onTap: () => _gotoViewImage(context, projectId, image.id),
+                  onTap: () => isSelecting
+                      ? _selectImage(context, image.id)
+                      : _gotoViewImage(context, projectId, image.id),
+                  onLongPress: () => !isSelecting
+                      ? _switchToMultiSelect(context, image.id)
+                      : null,
                 );
               }).toList(),
             ),
@@ -328,6 +376,45 @@ class ProjectDetailScreen extends StatelessWidget {
         ),
       ],
     );
+  }
+
+  List<PopupMenuEntry<int>> _buildImageActions(BuildContext context) {
+    return [
+      PopupMenuItem(
+        value: 0,
+        child: Text("Select all"),
+      ),
+      PopupMenuItem(
+        value: 1,
+        child: Text("Delete"),
+      ),
+      PopupMenuItem(
+        value: 2,
+        child: Text("Cancel"),
+      ),
+    ];
+  }
+
+  void _onImageAction(BuildContext context, int index) {
+    switch (index) {
+      case 0:
+        Provider.of<ProjectDetailBloc>(context).selectAllImages();
+        break;
+      case 1:
+        Provider.of<ProjectDetailBloc>(context).deleteSelected();
+        break;
+      case 2:
+        Provider.of<ProjectDetailBloc>(context).cancelSelection();
+        break;
+    }
+  }
+
+  void _switchToMultiSelect(BuildContext context, String id) {
+    Provider.of<ProjectDetailBloc>(context).selectImage(id);
+  }
+
+  void _selectImage(BuildContext context, String id) {
+    Provider.of<ProjectDetailBloc>(context).switchSelection(id);
   }
 
   void _gotoEditProject(BuildContext context, String id) {

--- a/labellab_mobile/lib/screen/project/detail/project_detail_state.dart
+++ b/labellab_mobile/lib/screen/project/detail/project_detail_state.dart
@@ -1,23 +1,24 @@
 import 'package:labellab_mobile/model/project.dart';
 
 class ProjectDetailState {
-  bool isLoading;
+  bool isLoading = false;
+  bool isSelecting = false;
   String error;
   Project project;
+  List<String> selectedImages = [];
 
   ProjectDetailState.loading({this.project}) {
     isLoading = true;
   }
 
-  ProjectDetailState.error(this.error, {this.project}) {
-    this.isLoading = false;
+  ProjectDetailState.error(this.error, {this.project});
+
+  ProjectDetailState.updateError(this.error, {this.project});
+
+  // Define state for images selection state
+  ProjectDetailState.multiSelect(this.project, {this.selectedImages}) {
+    isSelecting = true;
   }
 
-  ProjectDetailState.updateError(this.error, {this.project}) {
-    this.isLoading = false;
-  }
-
-  ProjectDetailState.success(this.project) {
-    this.isLoading = false;
-  }
+  ProjectDetailState.success(this.project);
 }


### PR DESCRIPTION
# Description

Implemented multiple images deleting feature. User can long press to switch to multiple image selection state. Once the images are selected, delete action can be triggered from the options menu.

Fixes #357 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots

![Screenshot_1584818559](https://user-images.githubusercontent.com/32796120/77234908-e1e14900-6bd7-11ea-9138-61b7b0e006e1.png)

![Screenshot_1584818562](https://user-images.githubusercontent.com/32796120/77234910-e7d72a00-6bd7-11ea-87a2-6e5c1bde2d5f.png)

![Screenshot_1584818567](https://user-images.githubusercontent.com/32796120/77234917-eefe3800-6bd7-11ea-8e8a-657297a09573.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
