### PR TITLE
Fix for not auto refreshing the charts in the project analytics page

### DIFF
--- a/labellab-client/src/components/project/analytics.js
+++ b/labellab-client/src/components/project/analytics.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { Header } from 'semantic-ui-react'
+import { Header, Grid } from 'semantic-ui-react'
 import { Bar, Pie } from 'react-chartjs-2'
 import './css/analytics.css'
 class AnalyticsIndex extends Component {
@@ -10,6 +10,8 @@ class AnalyticsIndex extends Component {
     return (
       <div className="project-analytics-parent">
         <div className="analytics-row">
+          <Grid columns={2} style={{width: '100%'}} stackable>
+          <Grid.Column  mobile={16} tablet={16} computer={8} className="analytics-column">
           <div className="project-analytics-section">
             <Header content="Time-Label Relationship" />
             {isfetching ? null : (
@@ -19,6 +21,8 @@ class AnalyticsIndex extends Component {
               />
             )}
           </div>
+          </Grid.Column>
+          <Grid.Column  mobile={16} tablet={16} computer={8} className="analytics-column">
           <div className="project-analytics-section">
             <Header content="Label Proportions" />
             {isfetching ? null : (
@@ -28,6 +32,8 @@ class AnalyticsIndex extends Component {
               />
             )}
           </div>
+          </Grid.Column>
+          </Grid>
         </div>
       </div>
     )

--- a/labellab-client/src/components/project/analytics.js
+++ b/labellab-client/src/components/project/analytics.js
@@ -6,7 +6,7 @@ import { Bar, Pie } from 'react-chartjs-2'
 import './css/analytics.css'
 class AnalyticsIndex extends Component {
   render() {
-    const { timeData, countData, isfetching } = this.props
+    const { timeData, countData, isfetching } = this.props        
     return (
       <div className="project-analytics-parent">
         <div className="analytics-row">
@@ -47,8 +47,8 @@ AnalyticsIndex.propTypes = {
 
 const mapStateToProps = state => {
   return {
-    timeData: state.analytics.timeData,
-    countData: state.analytics.countData,
+    timeData: state.analytics.timeData || {},
+    countData: state.analytics.countData || {},
     isfetching: state.analytics.isfetching
   }
 }

--- a/labellab-client/src/components/project/analytics.js
+++ b/labellab-client/src/components/project/analytics.js
@@ -4,9 +4,22 @@ import PropTypes from 'prop-types'
 import { Header, Grid } from 'semantic-ui-react'
 import { Bar, Pie } from 'react-chartjs-2'
 import './css/analytics.css'
+import {
+  getTimeLabel,
+  getLabelCount
+} from '../../actions/index'
+
 class AnalyticsIndex extends Component {
+  refreshData = () => {
+    const { project, getTimeLabel, getLabelCount } = this.props
+    getTimeLabel(project.projectId)  
+    getLabelCount(project.projectId) 
+  }
+  componentDidMount() {
+    this.refreshData();   
+  }
   render() {
-    const { timeData, countData, isfetching } = this.props        
+    const { timeData, countData, isfetching } = this.props   
     return (
       <div className="project-analytics-parent">
         <div className="analytics-row">
@@ -42,18 +55,33 @@ class AnalyticsIndex extends Component {
 
 AnalyticsIndex.propTypes = {
   analytics: PropTypes.object,
-  isfetching: PropTypes.bool
+  project: PropTypes.object,
+  isfetching: PropTypes.bool,
+  getTimeLabel: PropTypes.func,
+  getLabelCount: PropTypes.func
 }
 
 const mapStateToProps = state => {
   return {
+    project: state.projects.currentProject,
     timeData: state.analytics.timeData || {},
     countData: state.analytics.countData || {},
     isfetching: state.analytics.isfetching
   }
 }
 
+const mapDispatchToProps = dispatch => {  
+  return {
+    getTimeLabel: projectId => {
+      return dispatch(getTimeLabel(projectId))
+    },
+    getLabelCount: projectId => {
+      return dispatch(getLabelCount(projectId))
+    }
+  }
+}
+
 export default connect(
   mapStateToProps,
-  null
+  mapDispatchToProps
 )(AnalyticsIndex)

--- a/labellab-client/src/components/project/css/analytics.css
+++ b/labellab-client/src/components/project/css/analytics.css
@@ -1,5 +1,5 @@
 .project-analytics-parent {
-  margin: 2em;
+  margin: 0 2rem 2rem 0;
   display: flex;
   flex-direction: column;
 }

--- a/labellab-client/src/components/project/css/analytics.css
+++ b/labellab-client/src/components/project/css/analytics.css
@@ -11,10 +11,13 @@
 }
 
 .project-analytics-section {
-  width: 50%;
+  width: 100%;
   padding: 1em;
-  margin: 0.3em;
   box-shadow: 0px 0px 5px #ccc;
   border: 1px solid #ccc;
   border-radius: 20px;
+}
+
+.analytics-column {
+  padding-left: 0px !important;
 }

--- a/labellab-client/src/components/project/css/images.css
+++ b/labellab-client/src/components/project/css/images.css
@@ -50,3 +50,10 @@
 .max-size-error{
   color:red;
 }
+.custom-margin {
+  margin-bottom: 1rem !important;
+}
+.image-table-container {
+  width: 100%;
+  padding-right: 20px;
+}

--- a/labellab-client/src/components/project/css/index.css
+++ b/labellab-client/src/components/project/css/index.css
@@ -1,6 +1,21 @@
-.project-main{
-    display: flex;
+.project-main {
+  display: flex;
 }
-.project-non-side-section{
-    width: 75%;
+.project-non-side-section {
+  width: 100%;
+  margin-right: unset !important;
+}
+
+@media only screen and (max-width: 767px) {
+  .project-main {
+    margin: 0 !important;
+  }
+
+  .project-non-side-section {
+    padding: 10px;
+    max-width: unset !important;
+    width: 100% !important;
+    margin-right: unset !important;
+    min-height: 50%;
+  }
 }

--- a/labellab-client/src/components/project/css/projectDesc.css
+++ b/labellab-client/src/components/project/css/projectDesc.css
@@ -1,5 +1,5 @@
 .projectDesc-parent {
-  padding: 0.5em 0.5em 2em 0.5em;
+  padding: 2.5em 0.5em 2em 0.5em;
 }
 .projectDesc-header {
   display: flex;

--- a/labellab-client/src/components/project/css/sidebar.css
+++ b/labellab-client/src/components/project/css/sidebar.css
@@ -23,3 +23,23 @@
   margin-top: 2rem !important;
   width: 100%;
 }
+
+@media only screen and (max-width: 767px) {
+  .delete-project-button {
+    margin: 2rem 0 0 0 !important;
+    width: 100%;
+  }
+
+  .sidebar-parent {
+    width: 100%;
+    margin: 0 !important;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  .sidebar-menu-parent {
+    width: 100%;
+  }
+}

--- a/labellab-client/src/components/project/css/sidebar.css
+++ b/labellab-client/src/components/project/css/sidebar.css
@@ -20,5 +20,6 @@
   justify-content: center;
 }
 .delete-project-button {
-  width: 80%;
+  margin-top: 2rem !important;
+  width: 100%;
 }

--- a/labellab-client/src/components/project/css/team.css
+++ b/labellab-client/src/components/project/css/team.css
@@ -8,3 +8,7 @@
 .team-remove-user-icon:hover {
   cursor: pointer;
 }
+
+.ui.container{
+  margin-left: unset !important;
+}

--- a/labellab-client/src/components/project/css/team.css
+++ b/labellab-client/src/components/project/css/team.css
@@ -12,3 +12,9 @@
 .ui.container{
   margin-left: unset !important;
 }
+
+@media only screen and (max-width: 767px) {
+  .ui.container{
+    width: 100% !important;
+  }
+}

--- a/labellab-client/src/components/project/images.js
+++ b/labellab-client/src/components/project/images.js
@@ -168,9 +168,10 @@ class ImagesIndex extends Component {
             ) : null}
           </Form>
         ) : null}
+        <div className="image-table-container">
         <Table
           celled
-          style={{ display: 'flex', flexDirection: 'column', height: 600 }}
+          style={{ display: 'flex', flexDirection: 'column', height: 600, marginRight: 200, overflow: 'auto'  }}
         >
           <Table.Header className="image-table-header">
             <Table.Row className="flex image-table-row-back">
@@ -217,6 +218,7 @@ class ImagesIndex extends Component {
             ) : null}
           </Table.Body>
         </Table>
+        </div>
       </div>
     )
   }

--- a/labellab-client/src/components/project/label/index.js
+++ b/labellab-client/src/components/project/label/index.js
@@ -86,7 +86,7 @@ class LabelIndex extends Component {
     const { actions, labels } = this.props
     const { showform } = this.state
     return (
-      <Container>
+      <Container style={{overflow: 'auto'}}>
         {actions.isdeleting ? (
           <Dimmer active>
             <Loader indeterminate>Removing Label :)</Loader>

--- a/labellab-client/src/components/project/team.js
+++ b/labellab-client/src/components/project/team.js
@@ -100,7 +100,7 @@ class TeamIndex extends Component {
             />
           </Modal.Actions>
         </Modal>
-        <Table color="green" celled padded striped>
+        <Table color="green" celled padded striped stackable>
           <Table.Header>
             <Table.Row>
               <Table.HeaderCell singleLine>Project Members</Table.HeaderCell>

--- a/labellab-client/src/reducers/index.js
+++ b/labellab-client/src/reducers/index.js
@@ -18,7 +18,7 @@ const rootReducers = combineReducers({
   labels: label,
   searchProjects: searchProjects,
   searchUser: searchUser,
-  analytics
+  analytics: analytics
 })
 
 export default rootReducers


### PR DESCRIPTION
# Description

This includes a fix for the issue where the 2 charts in the Project Analytics page does not refresh upon adding new labels from Project Labels page.

Fixes
issue #388 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Create a new project
2. Go to project details by clicking on the project card from the dashboard
3. Click "Project Labels" from the sidebar
4. Add some labels using "Add Label" button (you can give any details for labels)
5. Click "Project Analytics" from the sidebar
6. Created labels are now visible on the 2 charts immediately.

Also, include screenshots of the app for the verification and reviewing purpose.

![image](https://user-images.githubusercontent.com/42619922/77512750-a5dd0b00-6e99-11ea-9cf6-e1344c888de9.png)
The chart before adding any labels

![image](https://user-images.githubusercontent.com/42619922/77512844-ca38e780-6e99-11ea-97b2-d53578c153e9.png)
Adding 3 new labels

![image](https://user-images.githubusercontent.com/42619922/77512876-dde44e00-6e99-11ea-99e4-656f2a42bf1a.png)
3 new labels are represented instantly in the charts (without needing to reload)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
