### PR TITLE
Add Tooltip to show hotkeys

### DIFF
--- a/labellab-client/src/components/labeller/LabelingApp.js
+++ b/labellab-client/src/components/labeller/LabelingApp.js
@@ -1,12 +1,10 @@
 import React, { Component } from 'react'
 import { withRouter } from 'react-router-dom'
-// import Hotkeys from 'react-hot-keys';
 import update from 'immutability-helper'
 
 import 'semantic-ui-css/semantic.min.css'
 
 import Canvas from './Canvas'
-// import HotkeysPanel from './HotkeysPanel';
 import Sidebar from './Sidebar'
 // import { PathToolbar, MakePredictionToolbar } from './CanvasToolbar';
 // import Reference from './Reference';
@@ -39,8 +37,7 @@ class LabelingApp extends Component {
       selectedFigureId: null,
 
       // UI
-      reassigning: { status: false, type: null },
-      hotkeysPanel: false
+      reassigning: { status: false, type: null, }
     }
 
     this.canvasRef = React.createRef()
@@ -162,9 +159,8 @@ class LabelingApp extends Component {
       //   });
       // break;
 
-      case "replace":
-        pushState(
-          state => {
+      case 'replace':
+        pushState((state) => {
           return {
             figures: update(state.figures, {
               [label.id]: {
@@ -181,10 +177,9 @@ class LabelingApp extends Component {
                 ]
               }
             })
-          };
-        });
-      break
-
+          }
+        })
+        break
 
       case 'delete':
         pushState(state => ({
@@ -258,7 +253,6 @@ class LabelingApp extends Component {
       // selectedFigureId,
       reassigning,
       toggles
-      // hotkeysPanel
     } = this.state
 
     const forwardedProps = {
@@ -294,7 +288,6 @@ class LabelingApp extends Component {
                 [label.id]: { $set: !toggles[label.id] }
               })
             }),
-          openHotkeys: () => this.setState({ hotkeysPanel: true }),
           onFormChange: (labelId, newValue) =>
             pushState(state => ({
               figures: update(figures, { [labelId]: { $set: newValue } })

--- a/labellab-client/src/components/labeller/Sidebar.js
+++ b/labellab-client/src/components/labeller/Sidebar.js
@@ -8,7 +8,9 @@ import {
   Form,
   Checkbox,
   Radio,
-  Select
+  Select,
+  Popup,
+  Grid,
 } from 'semantic-ui-react'
 import { shortcuts, colors } from './utils'
 import Hotkeys from 'react-hot-keys'
@@ -25,7 +27,6 @@ export default class Sidebar extends PureComponent {
       onToggle,
       filter,
       style,
-      openHotkeys,
       onBack,
       onSkip,
       onHome,
@@ -34,15 +35,6 @@ export default class Sidebar extends PureComponent {
       models,
       makePrediction
     } = this.props
-
-    const hotkeysButton = openHotkeys ? (
-      <Icon
-        link
-        name="keyboard"
-        style={headerIconStyle}
-        onClick={openHotkeys}
-      />
-    ) : null
 
     const getSelectHandler = ({ type, id }) =>
       type === 'bbox' || type === 'polygon' ? () => onSelect(id) : null
@@ -59,7 +51,34 @@ export default class Sidebar extends PureComponent {
       >
         <Header size="large" style={{ flex: '0 0 auto' }}>
           {title}
-          {hotkeysButton}
+          <Popup
+            flowing
+            content={
+              <Grid columns={2} style={{ width: '400px' }}>
+                <Grid.Row>
+                  <Grid.Column width={7}>Select Label:</Grid.Column>
+                  <Grid.Column width={9}>
+                    <Label>0</Label>-<Label>9</Label> and <Label>q</Label>,{' '}
+                    <Label>w</Label>, <Label>e</Label>
+                  </Grid.Column>
+                </Grid.Row>
+                <Grid.Row>
+                  <Grid.Column width={7}>Unselect Label:</Grid.Column>
+                  <Grid.Column width={9}>
+                    <Label>Esc</Label>
+                  </Grid.Column>
+                </Grid.Row>
+                <Grid.Row>
+                  <Grid.Column width={7}>Delete Polygon:</Grid.Column>
+                  <Grid.Column width={9}>
+                    Select Polygon + <Label>Del</Label>
+                  </Grid.Column>
+                </Grid.Row>
+              </Grid>
+            }
+            header="Shortcuts"
+            trigger={<Icon link name="keyboard" style={headerIconStyle} />}
+          />
         </Header>
         <List divided selection style={{ flex: 1, overflowY: 'auto' }}>
           {labels.map((label, i) =>


### PR DESCRIPTION
# Description

Earlier, the hotkeys button in the labeling app would not do anything when clicked. This has been changes so that on hovering over the hotkeys button, a Tooltip is shown which has the details of the shortcuts which the user can use.

Fixes #150  (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The labelling app was opened and the hotkeys button was hovered over in desktop view, and clicked in mobile view.

**Test Configuration**:
![Hotkeys](https://user-images.githubusercontent.com/9462834/78632476-adf16d80-78d1-11ea-9152-e3572f4fa2a8.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
