### PR TITLE
Add check to submit image only if lightbox not open

### DIFF
--- a/labellab-client/src/components/project/images.js
+++ b/labellab-client/src/components/project/images.js
@@ -59,6 +59,9 @@ class ImagesIndex extends Component {
 
   handleSubmit = e => {
     e.preventDefault()
+    if (this.state.isOpen) {
+      return
+    }
     const { project, fetchProject, submitImage } = this.props
     const { imageNames, images, format } = this.state
     if (this.state.file && this.state.file.size > 101200) {


### PR DESCRIPTION
# Description

The __View__ button which shows up once images are selected for uploading would open the images and then submit the automatically. A check has been added such that the `handleSubmit` button is not executed if the lightbox `isOpen`.

Fixes #411  (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

A single image as well as multiple images were uploaded. The __View__ button was clicked to see a preview of the images before clicking on __Submit__ to add the images.

**Test Configuration**:
N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
