### PR TITLE
Create layout for classifier model editor

### DIFF
--- a/labellab-client/src/components/index.js
+++ b/labellab-client/src/components/index.js
@@ -63,6 +63,11 @@ const ResetPassword = Loadable({
   loading: Loading
 })
 
+const ModelEditor = Loadable({
+  loader: () => import('../components/model-editor'),
+  loading: Loading
+})
+
 class App extends Component {
   render() {
     return (
@@ -80,6 +85,10 @@ class App extends Component {
             <PrivateRoute
               path={`/labeller/:projectId/:imageId`}
               component={Labeller}
+            />
+            <PrivateRoute
+              path={`/model_editor/:type/:projectId`}
+              component={ModelEditor}
             />
             <PrivateRoute path={`/project/:projectId`} component={Project} />
           </Switch>

--- a/labellab-client/src/components/model-editor/classifierEditor.js
+++ b/labellab-client/src/components/model-editor/classifierEditor.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react'
+import {Grid, Segment, Header} from "semantic-ui-react"
+
+import "./css/classifierEditor.css"
+
+class ClassifierEditor extends Component {
+    render() {
+        return (
+          <Grid stackable columns={3}>
+            <Grid.Column width={4}>
+              <Segment className="classifier-column-heading">
+                <Header>Classes</Header>
+              </Segment>
+            </Grid.Column>
+            <Grid.Column width={7}>
+              <Segment className="classifier-column-heading">
+                <Header>Train</Header>
+              </Segment>
+            </Grid.Column>
+            <Grid.Column width={5}>
+              <Segment className="classifier-column-heading">
+                <Header>Export/Test</Header>
+              </Segment>
+            </Grid.Column>
+          </Grid>
+        )
+    }
+}
+
+export default ClassifierEditor;

--- a/labellab-client/src/components/model-editor/css/classifierEditor.css
+++ b/labellab-client/src/components/model-editor/css/classifierEditor.css
@@ -1,0 +1,3 @@
+.classifier-column-heading {
+    text-align: center;
+}

--- a/labellab-client/src/components/model-editor/css/modelEditor.css
+++ b/labellab-client/src/components/model-editor/css/modelEditor.css
@@ -1,0 +1,7 @@
+.model-editor {
+    display: flex;
+    flex-direction: column;
+    margin: auto;
+    padding-top: 1em;
+    width: 95%;
+}

--- a/labellab-client/src/components/model-editor/index.js
+++ b/labellab-client/src/components/model-editor/index.js
@@ -1,0 +1,41 @@
+import React, { Component } from 'react'
+import {Container} from "semantic-ui-react"
+import Loadable from 'react-loadable'
+import Loader from '../loading/index'
+
+import "./css/modelEditor.css"
+
+const Loading = ({ error }) => {
+  if (error) return <div>Error loading component</div>
+  else return <Loader />
+}
+
+const ClassifierEditor = Loadable({
+  loader: () => import('./classifierEditor.js'),
+  loading: Loading
+})
+
+class ModelEditor extends Component {
+
+    getEditorType = () => {
+
+        const {type} = this.props.match.params;
+
+        switch(type) {
+            case "classifier":
+                return <ClassifierEditor />;
+            default:
+                return <div>Error loading component</div>
+        }
+    }
+
+    render() {
+        return (
+            <div className="model-editor">
+                {this.getEditorType()}
+            </div>
+        )
+    }
+}
+
+export default ModelEditor;


### PR DESCRIPTION
# Description

The basic layout of the classifier model editor has been added. Additionally, the `<ModelEditor />` component is extensible as it renders the type of editor based on the URL params.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Clicked on the __Create New Model__ button which opened up the model editor.

**Test Configuration**:
Layout of the model editor:
![modeleditor](https://user-images.githubusercontent.com/9462834/82122329-88eff480-97c5-11ea-88b8-6cbcc1d5c7cc.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
