### PR TITLE
Fixed margin issue when going back to dashboard

### DIFF
--- a/labellab-client/src/components/dashboard/css/dashboard.css
+++ b/labellab-client/src/components/dashboard/css/dashboard.css
@@ -4,6 +4,12 @@
   background: #e5e5e5;
   min-height: 100vh !important;
 }
+
+.dashboard-container {
+  width: 80%;
+  margin: auto;
+}
+
 .create-project-button {
   padding: 2em 0;
 }

--- a/labellab-client/src/components/dashboard/index.js
+++ b/labellab-client/src/components/dashboard/index.js
@@ -137,7 +137,7 @@ class Dashboard extends Component {
     return (
       <div className="dashboard-parent">
         <Navbar user={user} isfetching={isfetching} history={history} />
-        <Container className="home.container">
+        <div className="dashboard-container">
           {errors}
           <Dimmer active={isinitializing}>
             <Loader indeterminate>Preparing Files</Loader>
@@ -188,7 +188,7 @@ class Dashboard extends Component {
             <Header textAlign="left" as="h3" content="Previous Works" />
             <PreviousWork />
           </div>
-        </Container>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
# Description

When the user would go back to the dashboard from a project page, the margins of the dashboard would not be aligned to the center of the page. This PR fixes this problem by changing the className and the CSS properties

Fixes #419 (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Opened up a project and then clicked the browser's back button as well as the __Dashboard__ button in the navbar.

**Test Configuration**:

Margin after going back to dashboard:
![alignment](https://user-images.githubusercontent.com/9462834/82574582-e9ae7100-9bb9-11ea-9add-9c01b63145c8.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
