### PR TITLE
Add multiple image select support

### DIFF
--- a/labellab_mobile/android/app/src/main/AndroidManifest.xml
+++ b/labellab_mobile/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
     package="org.scorelab.labellab_mobile">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide

--- a/labellab_mobile/lib/screen/project/upload_image/project_upload_image_bloc.dart
+++ b/labellab_mobile/lib/screen/project/upload_image/project_upload_image_bloc.dart
@@ -18,9 +18,8 @@ class ProjectUploadImageBloc {
 
   ProjectUploadImageBloc(this.projectId);
 
-  void selectImage(File image) {
-    final _image = UploadImage(image: image);
-    _images.add(_image);
+  void selectImages(List<UploadImage> images) {
+    _images = _images + images;
     _stateController.add(ProjectUploadImageState.imageChange(images: _images));
   }
 

--- a/labellab_mobile/pubspec.yaml
+++ b/labellab_mobile/pubspec.yaml
@@ -39,6 +39,8 @@ dependencies:
   flutter_image_compress: ^0.6.5+1
   path_provider: ^1.6.5
   google_maps_flutter: ^0.5.27+1
+  multi_image_picker: ^4.6.7
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2


### PR DESCRIPTION
# Description

The current application supports multiple image upload. However, the user has to select the images one by one. This use can be improved by using the flutter multi-image select library which supports selecting multiple images at once. 

Related to #423 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots

**Image upload screen**
![Screenshot_1591715727](https://user-images.githubusercontent.com/32796120/84167882-684d4e80-aa94-11ea-99f0-9710c93527cd.png)

**Select image screen**
![Screenshot_1591715738](https://user-images.githubusercontent.com/32796120/84167923-74391080-aa94-11ea-8d38-950c0eaef595.png)

**Selecting multiple images** 
![Screenshot_1591715790](https://user-images.githubusercontent.com/32796120/84167943-78652e00-aa94-11ea-8d7b-963358ed1ddd.png)

**Selected images are loaded to upload screen**
![Screenshot_1591715794](https://user-images.githubusercontent.com/32796120/84167961-7ef3a580-aa94-11ea-85ca-11725fef66c1.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
