### PR TITLE
Add UI for showing training loss and accuracy graphs 

### DIFF
--- a/labellab-client/src/components/model-editor/classifierEditor.js
+++ b/labellab-client/src/components/model-editor/classifierEditor.js
@@ -6,6 +6,7 @@ import { Grid, Segment, Header, Button } from 'semantic-ui-react'
 import LabelSelector from './sub-modules/labelSelector'
 import PreprocessingSelector from './sub-modules/preprocessingSelector'
 import TransferLearningBuilder from './sub-modules/transferLearningBuilder'
+import TrainingGraphs from './sub-modules/trainingGraphs'
 
 import './css/classifierEditor.css'
 
@@ -43,6 +44,7 @@ class ClassifierEditor extends Component {
           <Segment className="classifier-column-heading">
             <Header>Export/Test</Header>
           </Segment>
+          <TrainingGraphs />
           <Button positive fluid onClick={() => saveModel(model)}>
             Save Changes
           </Button>

--- a/labellab-client/src/components/model-editor/sub-modules/css/trainingGraphs.css
+++ b/labellab-client/src/components/model-editor/sub-modules/css/trainingGraphs.css
@@ -1,0 +1,25 @@
+.training-graphs-card {
+  text-align: center;
+}
+
+.training-graphs {
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  overflow-x: scroll;
+}
+
+.training-graphs::-webkit-scrollbar {
+  display: none;
+}
+
+.training-graph {
+  height: 10em;
+  width: auto;
+}
+
+.training-results {
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+}

--- a/labellab-client/src/components/model-editor/sub-modules/trainingGraphs.js
+++ b/labellab-client/src/components/model-editor/sub-modules/trainingGraphs.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+import { Header, Card } from 'semantic-ui-react'
+
+import './css/trainingGraphs.css'
+
+class TrainingGraphs extends Component {
+  render() {
+    const { model } = this.props
+    return (
+      <Card centered fluid className="training-graphs-card">
+        <Card.Content>
+          <Header>Result</Header>
+        </Card.Content>
+        <Card.Content>
+          {model && (
+            <div className="training-graphs">
+              {model.lossGraphUrl && (
+                <img
+                  src={model.lossGraphUrl}
+                  alt="Loss graph"
+                  className="training-graph"
+                />
+              )}
+              {model.accuracyGraphUrl && (
+                <img
+                  src={model.accuracyGraphUrl}
+                  alt="Accuracy graph"
+                  className="training-graph"
+                />
+              )}
+            </div>
+          )}
+          {model && (
+            <div className="training-results">
+              {model.modelLoss && <div>Loss: {model.modelLoss}%</div>}
+              {model.modelAccuracy && (
+                <div>Accuracy: {model.modelAccuracy}%</div>
+              )}
+            </div>
+          )}
+        </Card.Content>
+      </Card>
+    )
+  }
+}
+
+TrainingGraphs.propTypes = {
+  model: PropTypes.object
+}
+
+const mapStateToProps = state => ({
+  model: state.model.model
+})
+
+export default connect(
+  mapStateToProps,
+  null
+)(TrainingGraphs)

--- a/labellab-client/src/reducers/model.js
+++ b/labellab-client/src/reducers/model.js
@@ -41,7 +41,11 @@ const initialState = {
     optimizer: null,
     transferSource: null,
     layers: [],
-    projectId: ''
+    projectId: '',
+    accuracyGraphUrl: '',
+    lossGraphUrl: '',
+    modelAccuracy: null,
+    modelLoss: null
   },
   models: []
 }


### PR DESCRIPTION
# Description

Once a model has been trained, it would help the user to see the accuracy and loss of the model with respect to the training and validation dataset with respect to time. This PR adds the UI for this feature.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Dummy graph links as well as accuracy and loss values were used to see the data on the dashboard

**Test Configuration**:

![graphs](https://user-images.githubusercontent.com/9462834/85191448-85361d00-b2f1-11ea-8bfd-6b9ad23ac6ba.PNG)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
