### PR TITLE
Implement image metadata fetch

### DIFF
--- a/labellab_mobile/lib/data/remote/labellab_api_impl.dart
+++ b/labellab_mobile/lib/data/remote/labellab_api_impl.dart
@@ -265,11 +265,33 @@ class LabelLabAPIImpl extends LabelLabAPI {
       String token, String projectId, UploadImage image) async {
     final imageBytes = image.image.readAsBytesSync();
     final encodedBytes = base64Encode(imageBytes);
+
+    final takenAt = (image.metadata != null &&
+            image.metadata.exif != null &&
+            image.metadata.exif.dateTime != null)
+        ? image.metadata.exif.dateTime
+        : "";
+    final latitude = (image.metadata != null &&
+            image.metadata.gps != null &&
+            image.metadata.gps.gpsLatitude != null)
+        ? image.metadata.gps.gpsLatitude
+        : "";
+    final longitude = (image.metadata != null &&
+            image.metadata.gps != null &&
+            image.metadata.gps.gpsLongitude != null)
+        ? image.metadata.gps.gpsLongitude
+        : "";
+
     final data = {
       "projectId": projectId,
       "imageNames": ["Image"],
       "images": ["base64," + encodedBytes],
       "format": "image/jpg",
+      "metadata": {
+        "takenAt": takenAt,
+        "latitude": latitude,
+        "longitude": longitude
+      }
     };
     Options options =
         Options(headers: {HttpHeaders.authorizationHeader: "Bearer " + token});

--- a/labellab_mobile/lib/model/upload_image.dart
+++ b/labellab_mobile/lib/model/upload_image.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:labellab_mobile/model/label.dart';
+import 'package:multi_image_picker/multi_image_picker.dart';
 
 class UploadImageState {
   static const PENDING = 0;
@@ -12,9 +13,11 @@ class UploadImageState {
 class UploadImage {
   int state;
   File image;
+  String name;
   List<Label> labels;
+  Metadata metadata;
 
-  UploadImage({this.image, this.labels}) {
+  UploadImage({this.image, this.name, this.labels, this.metadata}) {
     this.state = UploadImageState.PENDING;
   }
 }

--- a/labellab_mobile/lib/screen/project/upload_image/project_upload_image_bloc.dart
+++ b/labellab_mobile/lib/screen/project/upload_image/project_upload_image_bloc.dart
@@ -5,6 +5,7 @@ import 'package:labellab_mobile/data/repository.dart';
 import 'package:labellab_mobile/model/api_response.dart';
 import 'package:labellab_mobile/model/upload_image.dart';
 import 'package:labellab_mobile/screen/project/upload_image/project_upload_image_state.dart';
+import 'package:logger/logger.dart';
 import 'package:rxdart/rxdart.dart';
 
 class ProjectUploadImageBloc {
@@ -56,7 +57,7 @@ class ProjectUploadImageBloc {
       _stateController
           .add(ProjectUploadImageState.error(err.toString(), images: _images));
     }).listen((response) {
-      print(response.msg);
+      Logger().i(response.msg.toString());
     });
   }
 


### PR DESCRIPTION
# Description

Implement logic to fetch GPS and capture time data by image metadata. This location data will be used to generate the object path. 

Related to #423 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Ref

![has data](https://user-images.githubusercontent.com/32796120/85198729-a48c7480-b308-11ea-9b72-b2707cd1396c.png)
When an image has GPS data in its metadata, it will be saved. Otherwise, the `taken at`, `latitude` and `longitude` fields may append with empty strings.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
