### PR TITLE
Add backend for converting and exporting models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,8 +264,10 @@ db.sqlite3
 # Flask stuff:
 instance/
 .webassets-cache
-labellab-flask/api/static/steps/*
-labellab-flask/api/static/layers/*
+labellab-flask/model_files/graphs/*
+labellab-flask/model_files/layers/*
+labellab-flask/model_files/models/*
+labellab-flask/model_files/steps/*
 labellab-flask/public/uploads/*
 
 # Scrapy stuff:

--- a/labellab-flask/api/config.py
+++ b/labellab-flask/api/config.py
@@ -30,6 +30,7 @@ class DevelopmentConfig(Config):
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     # needs to be removed in further versions
+    ML_FILES_DIR = os.path.join(os.path.dirname(basedir),'model_files')
 
 
 class TestingConfig(Config):

--- a/labellab-flask/api/models/MLModel.py
+++ b/labellab-flask/api/models/MLModel.py
@@ -53,7 +53,7 @@ class MLModel(db.Model):
                     layers = {"layers": model_data[key]}
                     layers = json.dumps(layers)
                     layers = json.loads(layers)
-                    layers_url = f"./api/static/layers/{self.project_id}_{self.name}.json"
+                    layers_url = f"./model_files/layers/{self.project_id}_{self.name}.json"
                     with open(layers_url, "w") as f:
                         json.dump(layers, f)
                     self.layers_json_url = layers_url
@@ -63,7 +63,7 @@ class MLModel(db.Model):
                     preprocessing_steps = {"steps": model_data[key]}
                     preprocessing_steps = json.dumps(preprocessing_steps)
                     preprocessing_steps = json.loads(preprocessing_steps)
-                    steps_url = f"./api/static/steps/{self.project_id}_{self.name}.json"
+                    steps_url = f"./model_files/steps/{self.project_id}_{self.name}.json"
                     with open(steps_url, "w") as f:
                         json.dump(preprocessing_steps, f)
                     self.preprocessing_steps_json_url = steps_url

--- a/labellab-flask/api/routes/models.py
+++ b/labellab-flask/api/routes/models.py
@@ -12,6 +12,12 @@ modelsprint.add_url_rule(
 
 modelsprint.add_url_rule(
     "/models/train",
-    view_func=modelscontroller.modelController["save"],
+    view_func=modelscontroller.modelController["train"],
     methods=["POST"]
+)
+
+modelsprint.add_url_rule(
+    "/models/export",
+    view_func=modelscontroller.modelController["export"],
+    methods=["GET"]
 )

--- a/labellab-flask/requirements.txt
+++ b/labellab-flask/requirements.txt
@@ -48,6 +48,7 @@ mccabe==0.6.1
 nose==1.3.7
 numpy==1.16.4
 oauthlib==3.1.0
+onnx==1.7.0
 opencv-python==4.2.0.34
 opt-einsum==3.2.1
 pandas==1.0.4
@@ -80,7 +81,9 @@ tensorflow==2.2.0
 tensorflow-estimator==2.2.0
 termcolor==1.1.0
 tf-estimator-nightly==2.3.0.dev2020061601
+tf2onnx==1.6.2
 typing==3.7.4.1
+typing-extensions==3.7.4.2
 urllib3==1.25.9
 virtualenv==16.6.0
 Werkzeug==1.0.0


### PR DESCRIPTION
# Description

This PR adds the backend code which allows users to export their trained models in different formats

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Created a model using a test script and then used Postman to retrieve the model in `Saved Model`, `h5`, and `onnx` file formats.

**Test Configuration**:

![image](https://user-images.githubusercontent.com/9462834/85583090-890acc00-b670-11ea-9f53-34ad69c586fd.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
