### PR TITLE
Fix label-tool multi select bug

### DIFF
--- a/labellab_mobile/lib/screen/project/label_tool/label_tool_screen.dart
+++ b/labellab_mobile/lib/screen/project/label_tool/label_tool_screen.dart
@@ -47,7 +47,9 @@ class LabelToolScreen extends StatelessWidget {
           state.selections,
           true,
           onTap: (selection) {
-            Provider.of<LabelToolBloc>(context).updateSelection(selection);
+            !state.isUpdating
+                ? Provider.of<LabelToolBloc>(context).updateSelection(selection)
+                : null;
           },
           onDeleted: (selection) {
             Provider.of<LabelToolBloc>(context).removeSelection(selection);


### PR DESCRIPTION
# Description

Fixed the label tool multi select bug by adding a lock on selection onTap action. 

Fixes #469 
Related to #423 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
