### PR TITLE
fix-image-search: remove createdAt field

### DIFF
--- a/labellab-client/src/components/navbar/project.js
+++ b/labellab-client/src/components/navbar/project.js
@@ -19,16 +19,14 @@ import './css/navbar.css'
 
 const initialState = { isLoading: false, results: [], value: '' }
 
-const resultRenderer = ({ image_name, createdAt }) => (
+const resultRenderer = ({ image_name }) => (
   <>
     <Label content={image_name} />
-    <Label content={new Date(createdAt).toISOString().substring(0, 10)} />
   </>
 )
 
 resultRenderer.propTypes = {
-  title: PropTypes.string,
-  description: PropTypes.string
+  image_name: PropTypes.string,
 }
 
 class ProjectNavbar extends Component {


### PR DESCRIPTION
# Description
Fix the search images search bar.
Removed the image `createdAt` field and corrected the propTypes.
Note: Ordering is taken care of when fetching the data as it retrives data in the order it adds records.

Fixes #510 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
