### PR TITLE
fix-navbar-title-redirect: fix navbar title redirection to `/`

### DIFF
--- a/labellab-client/src/components/navbar/css/navbar.css
+++ b/labellab-client/src/components/navbar/css/navbar.css
@@ -70,6 +70,7 @@
   font-size: 1.5rem;
   font-weight: bold;
   padding: 20px 20px;
+  z-index: 1;
 }
 
 .navbar .menu-icon .nav-icon:before {


### PR DESCRIPTION
# Description

Fixes the dashboard to go back to the dashboard or "/".
This was due to the overlap between the search box and the navbar title.

Fixes #509 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
