### PR TITLE
[Mobile] Fixed login and register issue

### DIFF
--- a/labellab_mobile/lib/data/remote/dto/login_response.dart
+++ b/labellab_mobile/lib/data/remote/dto/login_response.dart
@@ -6,8 +6,8 @@ class LoginResponse {
 
   LoginResponse(dynamic json) {
     this.success = json['success'];
-    this.accessToken = json['access_token'];
-    this.refreshToken = json['refresh_token'];
+    this.accessToken = json['token'];
+    this.refreshToken = json['token'];
     this.msg = json['msg'];
   }
 }


### PR DESCRIPTION
# Description

I believe that earlier, on successsful login, the API used to return a refresh token and a access token. But that was changed earlier and now it only returns a single token. But the LoginResponse class in Mobile App wasn't changed to work with it, hence giving an 'Invalid Arguments' error. I've fixed the class to match the new response.

Fixes #526 

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Now I can login and register successfully on my local setup.

**Test Configuration**:

Realme 3 Pro Mobile

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
