### PR TITLE
[Mobile] View API Error Message on Login and Register failure

### DIFF
--- a/labellab_mobile/lib/data/remote/labellab_api_impl.dart
+++ b/labellab_mobile/lib/data/remote/labellab_api_impl.dart
@@ -91,7 +91,8 @@ class LabelLabAPIImpl extends LabelLabAPI {
         .post(API_URL + ENDPOINT_LOGIN, data: user.toMap())
         .then((response) {
       return LoginResponse(response.data);
-    });
+    }).catchError((err) =>
+            throw new Exception(jsonDecode(err.response.toString())['msg']));
   }
 
   @override
@@ -133,7 +134,8 @@ class LabelLabAPIImpl extends LabelLabAPI {
         .post(API_URL + ENDPOINT_REGISTER, data: user.toMap())
         .then((response) {
       return RegisterResponse(response.data);
-    });
+    }).catchError((err) =>
+            throw new Exception(jsonDecode(err.response.toString())['msg']));
   }
 
   @override

--- a/labellab_mobile/lib/screen/login/login_screen.dart
+++ b/labellab_mobile/lib/screen/login/login_screen.dart
@@ -169,7 +169,7 @@ class _LoginScreenState extends State<LoginScreen> {
           _isLoginIn = false;
         });
         print(err.message);
-        _showAuthFailSnackbar(context, err.message);
+        _showAuthFailSnackbar(context, message: err.message);
       });
     }
   }
@@ -191,7 +191,7 @@ class _LoginScreenState extends State<LoginScreen> {
         _isLoginIn = false;
       });
       print(err.toString());
-      _showAuthFailSnackbar(context, null);
+      _showAuthFailSnackbar(context);
     });
   }
 
@@ -221,7 +221,7 @@ class _LoginScreenState extends State<LoginScreen> {
         setState(() {
           _isLoginIn = false;
         });
-        _showAuthFailSnackbar(context, null);
+        _showAuthFailSnackbar(context);
       }
     });
   }
@@ -230,9 +230,10 @@ class _LoginScreenState extends State<LoginScreen> {
     Application.router.navigateTo(context, "/signup");
   }
 
-  void _showAuthFailSnackbar(BuildContext context, String message) {
+  void _showAuthFailSnackbar(BuildContext context,
+      {String message = "Sign in failed"}) {
     Scaffold.of(context).showSnackBar(SnackBar(
-      content: Text(message ?? "Sign in failed"),
+      content: Text(message),
       backgroundColor: Colors.redAccent,
     ));
   }

--- a/labellab_mobile/lib/screen/login/login_screen.dart
+++ b/labellab_mobile/lib/screen/login/login_screen.dart
@@ -168,8 +168,8 @@ class _LoginScreenState extends State<LoginScreen> {
         setState(() {
           _isLoginIn = false;
         });
-        print(err.toString());
-        _showAuthFailSnackbar(context);
+        print(err.message);
+        _showAuthFailSnackbar(context, err.message);
       });
     }
   }
@@ -191,7 +191,7 @@ class _LoginScreenState extends State<LoginScreen> {
         _isLoginIn = false;
       });
       print(err.toString());
-      _showAuthFailSnackbar(context);
+      _showAuthFailSnackbar(context, null);
     });
   }
 
@@ -221,7 +221,7 @@ class _LoginScreenState extends State<LoginScreen> {
         setState(() {
           _isLoginIn = false;
         });
-        _showAuthFailSnackbar(context);
+        _showAuthFailSnackbar(context, null);
       }
     });
   }
@@ -230,9 +230,9 @@ class _LoginScreenState extends State<LoginScreen> {
     Application.router.navigateTo(context, "/signup");
   }
 
-  void _showAuthFailSnackbar(BuildContext context) {
+  void _showAuthFailSnackbar(BuildContext context, String message) {
     Scaffold.of(context).showSnackBar(SnackBar(
-      content: Text("Sign in failed"),
+      content: Text(message ?? "Sign in failed"),
       backgroundColor: Colors.redAccent,
     ));
   }

--- a/labellab_mobile/lib/screen/sign_up/sign_up_screen.dart
+++ b/labellab_mobile/lib/screen/sign_up/sign_up_screen.dart
@@ -205,9 +205,9 @@ class _SignUpScreenState extends State<SignUpScreen> {
         setState(() {
           _isRegistering = false;
         });
-        print(err.toString());
+        print(err.message.toString());
         Scaffold.of(context).showSnackBar(SnackBar(
-          content: Text("Sign in failed"),
+          content: Text(err.message ?? "Sign in failed"),
           backgroundColor: Colors.redAccent,
         ));
       });


### PR DESCRIPTION
# Description

In the mobile application, when login or registration fails, it shows a generic error message which doesn't give much information.
After this change, it now shows the error message sent by the API.

Fixes #528 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Can by tested by**

1. Trying to login with wrong email or password
2. Trying to use already used email or username for registration

**Test Configuration**:

Realme 3 Pro

**Screenshots**

<ins>Eariler</ins>

<div style="flex-direction: row; margin-bottom: 20px;">
<img src='https://user-images.githubusercontent.com/45410599/105625014-34207580-5e4c-11eb-83c1-b4a71d177e4f.jpg' height='400px' style="margin-right: 10px;" />
<img src='https://user-images.githubusercontent.com/45410599/105625018-3c78b080-5e4c-11eb-8d2f-64928fdb196b.jpg' height='400px' />
</div>

<ins>After Change</ins>

<div style="flex-direction: row; margin-bottom: 10px;">
  <img src='https://user-images.githubusercontent.com/45410599/105625097-cde82280-5e4c-11eb-9fd4-6c60013c471b.jpg' height='400px' style="margin-right: 10px;" />
  <img src='https://user-images.githubusercontent.com/45410599/105625103-de989880-5e4c-11eb-8ff9-630d1ccf0183.jpg' height='400px' />
</div>

<div style="flex-direction: row; margin-bottom: 10px;">
  <img src='https://user-images.githubusercontent.com/45410599/105625186-65e60c00-5e4d-11eb-939f-c43d4a99f5fa.jpg' height='400px' style="margin-right: 10px;" />
  <img src='https://user-images.githubusercontent.com/45410599/105625164-40f19900-5e4d-11eb-82ae-3fae37875212.jpg' height='400px' />
</div>

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
