### PR TITLE
[Mobile] Fixed delete project functionality

### DIFF
--- a/labellab_mobile/lib/data/remote/labellab_api_impl.dart
+++ b/labellab_mobile/lib/data/remote/labellab_api_impl.dart
@@ -64,7 +64,7 @@ class LabelLabAPIImpl extends LabelLabAPI {
   static const ENDPOINT_PROJECT_INFO = "project/project_info";
   static const ENDPOINT_PROJECT_CREATE = "project/create";
   static const ENDPOINT_PROJECT_UPDATE = "project/project_info";
-  static const ENDPOINT_PROJECT_DELETE = "project/delete";
+  static const ENDPOINT_PROJECT_DELETE = "project/project_info";
   static const ENDPOINT_PROJECT_ADD_MEMBER = "project/add";
   static const ENDPOINT_PROJECT_REMOVE_MEMBER = "project/remove";
 


### PR DESCRIPTION
# Description

The delete project functionality was not working because of the incorrect route name for the API. It's working now with the Flask server by correcting the route.

Fixes #539 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

A Project now can be deleted through the mobile app.

**Test Configuration**:

Realme 3 Pro

https://user-images.githubusercontent.com/45410599/106709803-093bdb80-661b-11eb-9c87-29e06bc4565e.mp4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
