### PR TITLE
[Mobile] fixed BottomOverFlowed error of NavItem

### DIFF
--- a/labellab_mobile/lib/config_example.dart
+++ b/labellab_mobile/lib/config_example.dart
@@ -1,5 +1,0 @@
-/// This is the configuration file for LabelLab Mobile app.
-///
-/// Update following values with respective values and save the file as "config.dart" in the current directory.
-
-const String API_BASE_URL = "";

--- a/labellab_mobile/lib/screen/home/nav_item.dart
+++ b/labellab_mobile/lib/screen/home/nav_item.dart
@@ -33,9 +33,11 @@ class NavItem extends StatelessWidget {
               SizedBox(
                 height: 4,
               ),
-              Text(
-                label,
-                style: TextStyle(color: color),
+              FittedBox(
+                child: Text(
+                  label,
+                  style: TextStyle(color: color),
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
# Description
FittedBox restricts its child widgets from growing its size beyond a certain limit. It re-scales them according to the size available. 
So adding a FittedBox to the Text widget of NavItem solves the issue.


Fixes #541 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Tested on a physical device.

**Test Configuration**:
Android 9 (API Level 28)
![after](https://user-images.githubusercontent.com/55514928/106802147-8b161e00-6688-11eb-97df-4b5355148023.jpeg)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

