### PR TITLE
[Mobile] Finetune project details screen

### DIFF
--- a/labellab_mobile/lib/screen/project/detail/project_detail_screen.dart
+++ b/labellab_mobile/lib/screen/project/detail/project_detail_screen.dart
@@ -52,6 +52,7 @@ class ProjectDetailScreen extends StatelessWidget {
                   title: Text(
                     _state.project != null ? _state.project.name : "",
                     style: TextStyle(color: Colors.white),
+                    textAlign: TextAlign.center,
                   ),
                 ),
                 actions: _buildActions(context, _state.project),
@@ -145,17 +146,7 @@ class ProjectDetailScreen extends StatelessWidget {
                   ? _buildModels(
                       context, _state.project.id, _state.project.models)
                   : SliverFillRemaining(),
-              SliverList(
-                delegate: SliverChildListDelegate([
-                  Padding(
-                    padding: const EdgeInsets.only(top: 8.0, left: 16),
-                    child: Text(
-                      "Members",
-                      style: Theme.of(context).textTheme.headline6,
-                    ),
-                  ),
-                ]),
-              ),
+              _buildMembersHeading(context, _state.project),
               _state.project != null && _state.project.members != null
                   ? _buildMembers(context, _state.project.members)
                   : SliverFillRemaining(),
@@ -205,14 +196,10 @@ class ProjectDetailScreen extends StatelessWidget {
   List<Widget> _buildActions(BuildContext context, Project project) {
     return project != null
         ? [
-            IconButton(
-              icon: Icon(Icons.edit),
-              onPressed: () => _gotoEditProject(context, project.id),
-            ),
             PopupMenuButton<int>(
               onSelected: (int value) {
                 if (value == 0) {
-                  _gotoAddMemberScreen(context, project);
+                  _gotoEditProject(context, project.id);
                 } else if (value == 1) {
                   _showProjectDeleteConfirmation(context, project);
                 }
@@ -221,7 +208,7 @@ class ProjectDetailScreen extends StatelessWidget {
                 return [
                   PopupMenuItem(
                     value: 0,
-                    child: Text("Add member"),
+                    child: Text("Edit"),
                   ),
                   PopupMenuItem(
                     value: 1,
@@ -533,6 +520,30 @@ class ProjectDetailScreen extends StatelessWidget {
               ]),
             ),
           );
+  }
+
+  Widget _buildMembersHeading(BuildContext context, Project project) {
+    return SliverPadding(
+      padding: EdgeInsets.only(top: 8, left: 16, right: 16),
+      sliver: SliverList(
+        delegate: SliverChildListDelegate([
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              Text(
+                "Members",
+                style: Theme.of(context).textTheme.headline6,
+              ),
+              FlatButton.icon(
+                icon: Icon(Icons.add),
+                label: Text("Add"),
+                onPressed: () => _gotoAddMemberScreen(context, project),
+              ),
+            ],
+          ),
+        ]),
+      ),
+    );
   }
 
   IconData _getIcon(ModelSource source) {


### PR DESCRIPTION
# Description

The UI for Project Details Screen was not very compatible with long project names. Resolved by - 
1. Center aligning the project name in app bar.
2. Removing add member action from app bar and placing it with members list section, similar to other sections such as groups, images etc in the same screen.
3. Moving edit button and delete button to one Popup Menu Button so that there is more space for the Project Name.

Fixes #543 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

**Test Configuration**:

Android 10

<div style="flex-direction: row; margin-bottom: 20px;">
<img src='https://user-images.githubusercontent.com/45410599/106862658-6e600180-66ed-11eb-993d-6def884df8f5.jpg' height='400px' style="margin-right: 10px;" />
<img src='https://user-images.githubusercontent.com/45410599/106862661-6f912e80-66ed-11eb-867e-1616bd623e3e.jpg' height='400px' />
</div>

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
