### PR TITLE
Fixed delete project member functionality

### DIFF
--- a/labellab_mobile/lib/data/remote/labellab_api_impl.dart
+++ b/labellab_mobile/lib/data/remote/labellab_api_impl.dart
@@ -66,7 +66,7 @@ class LabelLabAPIImpl extends LabelLabAPI {
   static const ENDPOINT_PROJECT_UPDATE = "project/project_info";
   static const ENDPOINT_PROJECT_DELETE = "project/delete";
   static const ENDPOINT_PROJECT_ADD_MEMBER = "project/add";
-  static const ENDPOINT_PROJECT_REMOVE_MEMBER = "project/remove";
+  static const ENDPOINT_PROJECT_REMOVE_MEMBER = "project/remove_project_member";
 
   static const ENDPOINT_IMAGE = "image";
   static const ENDPOINT_IMAGES = "images";
@@ -289,7 +289,7 @@ class LabelLabAPIImpl extends LabelLabAPI {
       headers: {HttpHeaders.authorizationHeader: "Bearer " + token},
     );
     final data = {
-      "memberEmail": email,
+      "member_email": email,
     };
     return _dio
         .post(API_URL + ENDPOINT_PROJECT_REMOVE_MEMBER + "/$projectId",

--- a/labellab_mobile/lib/screen/project/detail/project_detail_screen.dart
+++ b/labellab_mobile/lib/screen/project/detail/project_detail_screen.dart
@@ -558,7 +558,7 @@ class ProjectDetailScreen extends StatelessWidget {
             return ListTile(
               title: Text(member.name),
               subtitle: Text(member.email),
-              trailing: _currentUser.name != member.name
+              trailing: _currentUser.email != member.email
                   ? PopupMenuButton<int>(
                       onSelected: (value) {
                         if (value == 0) {


### PR DESCRIPTION
# Description

The delete project member functionality was not working. Fixed it with the following measures - 
1. Corrected the route name and data sent in the request to work with Flask API.
2. If some other project member had the same name as you, the delete option wouldn't show up at all. Fixed it by using email instead of name for comparison, as email will always be unique.

Fixes #552 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Go to Projects section
2. Open a project
3. Try to delete a member other than yourself

**Test Configuration**:

- Realme 3 Pro
- Android 10

https://user-images.githubusercontent.com/45410599/107111878-7c428d80-6879-11eb-8b89-752a5d46fe31.mp4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
