### PR TITLE
Added duplicate project name check in edit project route

### DIFF
--- a/labellab-flask/api/controllers/projectscontroller.py
+++ b/labellab-flask/api/controllers/projectscontroller.py
@@ -242,6 +242,18 @@ class ProjectInfo(MethodView):
             }
             return make_response(jsonify(response)), 400
 
+        # Search the database for this project_name
+        project = find_by_project_name(project_name)
+
+        if project and project['id'] != project_id:
+            # There already exists another project with the same name.
+            # So we can't let this project use that name
+            response = {
+                "success": False,
+                "msg": "Project name already taken."
+            }
+            return make_response(jsonify(response)), 400
+
         try:
             project = find_by_project_id(project_id)
             project['members'] = get_projectmembers(project_id)


### PR DESCRIPTION
# Description

Earlier it was possible to end up with 2 projects having the same name. Added an input check to prevent that.

Fixes #558 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Try editing a project and changing its name to that of another existing project.

**Test Configuration**:

Windows 10

https://user-images.githubusercontent.com/45410599/107782097-a8c14280-6d6e-11eb-87de-5e8921108b21.mp4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
