### PR TITLE
[Mobile] Fixed autofill text bug in edit project screen

### DIFF
--- a/labellab_mobile/lib/screen/project/add_edit/add_edit_project_screen.dart
+++ b/labellab_mobile/lib/screen/project/add_edit/add_edit_project_screen.dart
@@ -55,6 +55,7 @@ class _AddEditProjectScreenState extends State<AddEditProjectScreen> {
                 labelText: "Project name",
                 textCapitalization: TextCapitalization.words,
                 validator: _validateName,
+                controller: _nameController,
               ),
               SizedBox(
                 height: 8,
@@ -67,6 +68,7 @@ class _AddEditProjectScreenState extends State<AddEditProjectScreen> {
                 labelText: "Project description",
                 textCapitalization: TextCapitalization.sentences,
                 validator: _validateDescription,
+                controller: _descriptionController,
               ),
               this._error != null
                   ? Text(

--- a/labellab_mobile/lib/widgets/label_text_form_field.dart
+++ b/labellab_mobile/lib/widgets/label_text_form_field.dart
@@ -10,6 +10,7 @@ class LabelTextFormField extends StatefulWidget {
   final TextInputType keyboardType;
   final validator;
   final onSaved;
+  final TextEditingController controller;
 
   LabelTextFormField({
     this.key,
@@ -21,6 +22,7 @@ class LabelTextFormField extends StatefulWidget {
     this.labelText,
     this.validator,
     this.onSaved,
+    this.controller,
   });
 
   @override
@@ -35,6 +37,7 @@ class _LabelTextFormFieldState extends State<LabelTextFormField> {
     return ClipRRect(
       borderRadius: BorderRadius.circular(8),
       child: TextFormField(
+        controller: widget.controller,
         key: widget.key,
         decoration: new InputDecoration(
           hintText: widget.hintText,


### PR DESCRIPTION
# Description

Fixed the bug so that now while editing a project, the text fields are filled with the current data.
The logic for this was already present. While editing a project, the text editing controller's data was updated to current project data. But the controller was not assigned to the text field. Due to this it was not working. I fixed that.

Fixes #590 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Go to a Project
2. Click the edit project option

**Test Configuration**:

- Android 10
- Realme 3 Pro

https://user-images.githubusercontent.com/45410599/112291581-3cfbbf00-8cb6-11eb-91e5-ad2f3bad5349.mp4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
