### PR TITLE
Method Not Found "ImageCropper.cropImage"

### DIFF
--- a/labellab_mobile/lib/screen/project/upload_image/project_upload_image_screen.dart
+++ b/labellab_mobile/lib/screen/project/upload_image/project_upload_image_screen.dart
@@ -204,7 +204,7 @@ class ProjectUploadImageScreen extends StatelessWidget {
         Provider.of<ProjectUploadImageBloc>(context, listen: false)
             .getImageIndex(image);
 
-    File? editedFile = await ImageCropper.cropImage(
+    File? editedFile = await ImageCropper().cropImage(
         sourcePath: image.image!.path,
         aspectRatioPresets: Platform.isAndroid
             ? [


### PR DESCRIPTION
# Description
labellab_mobile/lib/screen/project/upload_image/project_upload_image_screen.dart 
     Error: Method not found: 'ImageCropper.cropImage'.
     
 Reference taken from 
https://github.com/hnvn/flutter_image_cropper/issues/315#issuecomment-1047047274


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Flutter version 2.8.1

Also, include screenshots of app for the verification and reviewing purpose.
