### PR TITLE
Created an instance for Imagecropper

### DIFF
--- a/labellab_mobile/lib/screen/project/upload_image/project_upload_image_screen.dart
+++ b/labellab_mobile/lib/screen/project/upload_image/project_upload_image_screen.dart
@@ -203,8 +203,10 @@ class ProjectUploadImageScreen extends StatelessWidget {
     final imageIndex =
         Provider.of<ProjectUploadImageBloc>(context, listen: false)
             .getImageIndex(image);
+    
+    final _imageCropper = ImageCropper();
 
-    File? editedFile = await ImageCropper.cropImage(
+    File? editedFile = await _imageCropper.cropImage(
         sourcePath: image.image!.path,
         aspectRatioPresets: Platform.isAndroid
             ? [

--- a/labellab_mobile/lib/screen/project/upload_image/project_upload_image_screen.dart
+++ b/labellab_mobile/lib/screen/project/upload_image/project_upload_image_screen.dart
@@ -14,6 +14,10 @@ import 'package:provider/provider.dart';
 import 'package:rxdart/rxdart.dart';
 
 class ProjectUploadImageScreen extends StatelessWidget {
+  
+  // Instance for imagecropper
+  final _imageCropper = ImageCropper();
+  
   @override
   Widget build(BuildContext context) {
     return StreamBuilder(
@@ -203,8 +207,6 @@ class ProjectUploadImageScreen extends StatelessWidget {
     final imageIndex =
         Provider.of<ProjectUploadImageBloc>(context, listen: false)
             .getImageIndex(image);
-    
-    final _imageCropper = ImageCropper();
 
     File? editedFile = await _imageCropper.cropImage(
         sourcePath: image.image!.path,


### PR DESCRIPTION
# Description
 Currently cropImage is no longer a static to the class in the ImageCropper package.

created an instance at the top level of the widget.

Reference taken from [issue315](https://github.com/hnvn/flutter_image_cropper/issues/315#issuecomment-1047047274)

Fixes #626 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
