### PR TITLE
Issue #633: Fix insufficient password length warning

### DIFF
--- a/labellab-client/src/components/register/index.js
+++ b/labellab-client/src/components/register/index.js
@@ -188,6 +188,11 @@ class RegisterIndex extends Component {
                 Password cannot be empty!
               </Label>
             )}
+            {password && password.length < 8 && (
+              <Label pointing color="red">
+                Passwords length should be greater than 8!
+              </Label>
+            )}
             {statusText && errField === 'password' && (
               <Label pointing color="red">
                 {statusText}


### PR DESCRIPTION
# Description

Added a warning label if the password length is less than 8 while entering a password.

Fixes #636

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `npm test`
- [x] `flask test`


Also, include screenshots of the app for the verification and reviewing purpose.

https://user-images.githubusercontent.com/69365878/161368311-e0484dc1-9fd6-4692-8571-ebcb9b1b1db6.mp4


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
