### PR TITLE
Implement Endpoints for Single Comment (GET, PUT, DELETE)

### DIFF
--- a/labellab-flask/api/config.py
+++ b/labellab-flask/api/config.py
@@ -21,7 +21,7 @@ class Config:
     LABELS_ALLOWED = ["bbox","polygon"]
     TEAMS_ALLOWED = ["labels","images","image labelling","models"]
     CATEGORIES_ALLOWED = ["general","labels","images","image labelling","issues","models","misc"]
-    ENTITY_TYPES_ALLOWED = ["label","image", "model", "issue"]
+    ENTITY_TYPES_ALLOWED = ["label","image", "model", "issue","comment"]
     ISSUE_PRIORITIES_ALLOWED = ["Critical", "High", "Medium", "Low"]
     ISSUE_STATUSES_ALLOWED = ["Open", "In Progress", "Review", "Done", "Closed"]
     @staticmethod

--- a/labellab-flask/api/config.py
+++ b/labellab-flask/api/config.py
@@ -20,7 +20,7 @@ class Config:
     JWT_BLACKLIST_TOKEN_CHECKS = ["access", "refresh"]
     LABELS_ALLOWED = ["bbox","polygon"]
     TEAMS_ALLOWED = ["labels","images","image labelling","models"]
-    CATEGORIES_ALLOWED = ["general","labels","images","image labelling","issues","models","misc"]
+    CATEGORIES_ALLOWED = ["general","labels","images","image labelling","models","misc"]
     ENTITY_TYPES_ALLOWED = ["label","image", "model", "issue","comment"]
     ISSUE_PRIORITIES_ALLOWED = ["Critical", "High", "Medium", "Low"]
     ISSUE_STATUSES_ALLOWED = ["Open", "In Progress", "Review", "Done", "Closed"]

--- a/labellab-flask/api/controllers/issuecontroller.py
+++ b/labellab-flask/api/controllers/issuecontroller.py
@@ -20,7 +20,7 @@ from api.helpers.issue import (
     update_issue,
     fetch_all_issue_by_team_id
 )
-
+from api.helpers.comment import fetch_comments_by_issue_id
 from api.helpers.user import get_user_roles
 
 from api.middleware.logs_decorator import record_logs
@@ -171,7 +171,7 @@ class IssueInfo(MethodView):
                 return make_response(jsonify(response)), 400
             
             issue = find_by_id(issue_id)
-
+            issue['comments'] = fetch_comments_by_issue_id(issue_id)
             response = {
                 "success": True,
                 "msg": "Issue found",

--- a/labellab-flask/api/helpers/comment.py
+++ b/labellab-flask/api/helpers/comment.py
@@ -1,12 +1,41 @@
 import os
 
 from api.extensions import db, ma
+from api.models.Comment import Comment
 from api.serializers.comment import CommentSchema
 
-comment_scheme = CommentSchema()
-comments_scheme = CommentSchema(many =True)
+comment_schema = CommentSchema()
+comments_schema = CommentSchema(many =True)
 
+def to_json(comment):
+    """
+    Returns a Comment JSON object
+    """
+    return comment_schema.dump(comment).data
 
+def find_by_id(_id):
+    """
+    query comment on their id
+    """
+    comment = Comment.query.filter_by(id=_id).first()
+    return comment_schema.dump(comment).data
+
+def update_comment(comment_id, data):
+    """
+    update comment using its id.
+    """
+    comment = Comment.query.get(comment_id)
+    for attribute in data:
+        setattr(comment, attribute, data[attribute])
+    db.session.commit()
+    return comment_schema.dump(comment).data
+
+def delete_by_id(_id):
+    """
+    Delete comment by their id
+    """
+    Comment.query.filter_by(id=_id).delete()
+    db.session.commit()
 def save(comment):
     """
     Save an comment to the database.
@@ -14,4 +43,4 @@ def save(comment):
     """
     db.session.add(comment)
     db.session.commit()
-    return comment_scheme.dump(comment).data
+    return comment_schema.dump(comment).data

--- a/labellab-flask/api/helpers/comment.py
+++ b/labellab-flask/api/helpers/comment.py
@@ -7,6 +7,11 @@ from api.serializers.comment import CommentSchema
 comment_schema = CommentSchema()
 comments_schema = CommentSchema(many =True)
 
+# Fetch comments of an issue
+def fetch_comments_by_issue_id(issue_id):
+    comments = Comment.query.filter_by(issue_id=issue_id).all()
+    return list(map(lambda comment: to_json(comment), comments))
+
 def to_json(comment):
     """
     Returns a Comment JSON object

--- a/labellab-flask/api/middleware/comment_decorator.py
+++ b/labellab-flask/api/middleware/comment_decorator.py
@@ -1,0 +1,23 @@
+from functools import wraps
+from flask import jsonify, make_response
+from flask_jwt_extended import get_jwt_identity
+
+from api.helpers.comment import find_by_id
+
+def comment_exists(fun):
+  @wraps(fun)
+  def wrap(*args, **kwargs):
+
+    # Get comment id
+    comment_id = kwargs.get('comment_id')
+    comment = find_by_id(comment_id)
+
+    if not comment:
+      response = {
+        'success': False,
+        'msg': 'comment does not exist',
+      }
+      return make_response(jsonify(response)), 404
+
+    return fun(*args, **kwargs)
+  return wrap

--- a/labellab-flask/api/middleware/logs_decorator.py
+++ b/labellab-flask/api/middleware/logs_decorator.py
@@ -14,6 +14,7 @@ from api.helpers.user import (
 from api.helpers.team import find_by_id as find_team_by_id
 from api.helpers.label import find_by_id as find_label_by_id
 from api.helpers.issue import find_by_id as find_issue_by_id
+from api.helpers.comment import find_by_id as find_comment_by_id
 from api.helpers.mlclassifier import find_by_id as find_mlclassifer_by_id
 from api.helpers.project import find_by_project_id
 
@@ -169,9 +170,23 @@ def record_logs(fun):
         project_id = issue['project_id']
         project = find_by_project_id(project_id)
         message = f'{user["username"]} posted a new comment on {project["project_name"]}'
-        category = 'comments'
-        
+        category = 'issues'
 
+      if url.startswith('/api/v1/comment/comment_info/'):
+        comment_id = kwargs.get('comment_id')
+        issue_id = kwargs.get('issue_id')
+        issue = find_issue_by_id(issue_id)
+        project_id = issue['project_id']
+        if method == 'DELETE':
+          message = f'Comment with id {comment_id} has been deleted'
+          category = 'issues'
+        elif method == 'PUT':
+          comment = find_comment_by_id(comment_id)
+          message = f'{user["username"]} edited the comment'
+          category = 'issues'
+          entity_type = 'comment'
+          entity_id = comment_id
+        
       # Labels controller
       if url == f'/api/v1/label/create/{project_id}':
         message = 'New label has been created'

--- a/labellab-flask/api/middleware/logs_decorator.py
+++ b/labellab-flask/api/middleware/logs_decorator.py
@@ -139,18 +139,18 @@ def record_logs(fun):
 
       # Issues controller
       if url == f'/api/v1/issue/create/{project_id}':
+        data = request.get_json(silent=True, force=True)
         message = 'New issue has been created'
-        category = 'issues'
+        category = data['category']
       
       if url.startswith('/api/v1/issue/issue_info/'):
         issue_id = kwargs.get('issue_id')
         if method == 'DELETE':
           message = f'Issue with id {issue_id} has been deleted'
-          category = 'issues'
         elif method == 'PUT':
           issue = find_issue_by_id(issue_id)
           message = f'Issue {issue["title"]} has been updated'
-          category = 'issues'
+          category = issue["category"]
           entity_type = 'issue'
           entity_id = issue_id
 
@@ -161,7 +161,7 @@ def record_logs(fun):
         user = find_by_user_id(assignee_id)
         issue = find_issue_by_id(issue_id)
         message = f'Issue {issue["title"]} assigned to {user["name"]}'
-        category = 'issues'
+        category = issue["category"]
      
       # Comment controller
       if url.startswith('/api/v1/comment/create/'):
@@ -169,23 +169,8 @@ def record_logs(fun):
         issue = find_issue_by_id(issue_id)
         project_id = issue['project_id']
         project = find_by_project_id(project_id)
-        message = f'{user["username"]} posted a new comment on {project["project_name"]}'
-        category = 'issues'
-
-      if url.startswith('/api/v1/comment/comment_info/'):
-        comment_id = kwargs.get('comment_id')
-        issue_id = kwargs.get('issue_id')
-        issue = find_issue_by_id(issue_id)
-        project_id = issue['project_id']
-        if method == 'DELETE':
-          message = f'Comment with id {comment_id} has been deleted'
-          category = 'issues'
-        elif method == 'PUT':
-          comment = find_comment_by_id(comment_id)
-          message = f'{user["username"]} edited the comment'
-          category = 'issues'
-          entity_type = 'comment'
-          entity_id = comment_id
+        message = f'{user["username"]} posted a new comment on {issue["title"]}'
+        category = issue["category"]
         
       # Labels controller
       if url == f'/api/v1/label/create/{project_id}':

--- a/labellab-flask/api/models/Comment.py
+++ b/labellab-flask/api/models/Comment.py
@@ -20,11 +20,12 @@ class Comment(db.Model):
                        default='https://react.semantic-ui.com/images/avatar/large/elliot.jpg')
     timestamp = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
-    def __init__(self, body, issue_id, user_id, username):
+    def __init__(self, body, issue_id, user_id, username, thumbnail):
         self.body = body
         self.issue_id = issue_id
         self.user_id = user_id
         self.username = username
+        self.thumbnail = thumbnail
 
     def __repr__(self):
         """

--- a/labellab-flask/api/serializers/project.py
+++ b/labellab-flask/api/serializers/project.py
@@ -3,6 +3,7 @@ from marshmallow import Schema, fields
 from api.extensions import db, ma
 from api.serializers.image import ImageSchema
 from api.serializers.label import LabelSchema
+from api.serializers.issue import IssueSchema
 
 class ProjectSchema(ma.ModelSchema):
     """
@@ -15,3 +16,4 @@ class ProjectSchema(ma.ModelSchema):
     admin_id = fields.Int(dump_only=True)
     images = fields.Nested(ImageSchema, many=True)
     labels = fields.Nested(LabelSchema, many=True)
+    issues = fields.Nested(IssueSchema, many=True)


### PR DESCRIPTION
# Description

#### 1) Implement following endpoints for Single Comment :
- Get a particular comment ( GET - `/api/v1/comment/comment_info/<int:issue_id>/<int:comment_id>`)
- Update comment ( PUT - `/api/v1/comment/comment_info/<int:issue_id>/<int:comment_id>`)
- Delete comment( DELETE - `/api/v1/comment/comment_info/<int:issue_id>/<int:comment_id>`)

Also made a minor change in create comment endpoint to also include thumbnail of the user (other than default) if user has uploaded one.

#### 2) Modified logs decorator to create logs for above endpoints. ( Though, i  think we do not need logs for updation/deletion of comments)

#### 3) Modify issue details route (GET) to also fetch the list of comments. Also modified projects serializer to include issues.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Test Configuration**:

- Ubuntu20.04
- Postman

https://user-images.githubusercontent.com/76858666/174435291-c9fa8111-add9-4110-8f2f-7bf2f0c238d1.mp4

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
