### PR TITLE
Add custom 404 and 401 error pages

### DIFF
--- a/labellab-client/src/actions/issue.js
+++ b/labellab-client/src/actions/issue.js
@@ -170,9 +170,14 @@ import {
         })
         .catch(err => {
           if (err.response) {
-            err.response.data
+            if(err.response.status==404 || err.response.status==401) {
+              dispatch(failure(err.response.status))
+            }
+            else {
+              err.response.data.msg
               ? dispatch(failure(err.response.data.msg))
-              : dispatch(failure(err.response.statusText, null))
+              : dispatch(failure(err.response.statusText))
+            }
           }
         })
     }

--- a/labellab-client/src/actions/project/fetchDetails.js
+++ b/labellab-client/src/actions/project/fetchDetails.js
@@ -48,9 +48,14 @@ export const fetchProject = (data, callback) => {
       })
       .catch(err => {
         if (err.response) {
-          err.response.data
+          if(err.response.status==404 || err.response.status==401) {
+            dispatch(failure(err.response.status))
+          }
+          else {
+            err.response.data.msg
             ? dispatch(failure(err.response.data.msg))
-            : dispatch(failure(err.response.statusText, null))
+            : dispatch(failure(err.response.statusText))
+          }
         }
       })
   }

--- a/labellab-client/src/actions/project/teams.js
+++ b/labellab-client/src/actions/project/teams.js
@@ -87,9 +87,14 @@ export const fetchTeam = (projectId, teamId) => {
       .then(res => dispatch(success(res.data.body)))
       .catch(err => {
         if (err.response) {
-          err.response.data
+          if(err.response.status==404 || err.response.status==401) {
+            dispatch(failure(err.response.status))
+          }
+          else {
+            err.response.data.msg
             ? dispatch(failure(err.response.data.msg))
-            : dispatch(failure(err.response.statusText, null))
+            : dispatch(failure(err.response.statusText))
+          }
         }
       })
   }

--- a/labellab-client/src/components/error/css/notfound.css
+++ b/labellab-client/src/components/error/css/notfound.css
@@ -1,0 +1,16 @@
+.main {
+    height: 50vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+.heading {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    font-size: 5em;
+
+}
+.green {
+    color: green
+}

--- a/labellab-client/src/components/error/notFound.js
+++ b/labellab-client/src/components/error/notFound.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react'
+import { Link } from 'react-router-dom'
+import { Header, Button } from 'semantic-ui-react'
+import './css/notfound.css'
+class NotFound extends Component {
+  render() {
+    return (
+      <div className="main">
+        <Header textAlign="center">
+          <Header.Content>
+            <div className='heading'>
+              <div>4 </div>
+              <div className='green'>0 </div>
+              <div>4</div>
+            </div>
+            <br />
+            <Header as='h2' content="OOPS! PAGE NOT FOUND" />
+            <br />
+            <Header as='h3' content="The page you requested could not be found" />
+            <br/>
+            <Link to="/">
+              <Button basic color='green'>
+                Go to Dashboard
+              </Button>
+            </Link>
+          </Header.Content>
+        </Header>
+      </div>
+    )
+  }
+}
+
+export default NotFound

--- a/labellab-client/src/components/error/unauthorized.js
+++ b/labellab-client/src/components/error/unauthorized.js
@@ -1,0 +1,33 @@
+import React, { Component } from 'react'
+import { Link } from 'react-router-dom'
+import { Header, Button } from 'semantic-ui-react'
+import './css/notfound.css'
+class Unauthorized extends Component {
+  render() {
+    return (
+      <div className="main">
+        <Header textAlign="center">
+          <Header.Content>
+            <div className='heading'>
+              <div>4 </div>
+              <div className='green'>0 </div>
+              <div>1</div>
+            </div>
+            <br />
+            <Header as='h2' content="UNAUTHORIZED" />
+            <br />
+            <Header as='h3' content="You do not have the required permissions to view this page" />
+            <br/>
+            <Link to="/">
+              <Button basic color='green'>
+                Go to Dashboard
+              </Button>
+            </Link>
+          </Header.Content>
+        </Header>
+      </div>
+    )
+  }
+}
+
+export default Unauthorized

--- a/labellab-client/src/components/index.js
+++ b/labellab-client/src/components/index.js
@@ -53,6 +53,16 @@ const Redirect = Loadable({
   loading: Loading
 })
 
+const NotFound = Loadable({
+  loader: () => import('./error/notFound.js'),
+  loading: Loading
+})
+
+const Unauthorized = Loadable({
+  loader: () => import('./error/unauthorized.js'),
+  loading: Loading
+})
+
 const ForgotPassword = Loadable({
   loader: () => import('../components/login/ForgotPassword'),
   loading: Loading
@@ -91,6 +101,9 @@ class App extends Component {
               component={ModelEditor}
             />
             <PrivateRoute path={`/project/:projectId`} component={Project} />
+            <Route path="/404" component={NotFound}/>
+            <Route path="/401" component={Unauthorized}/>
+            <Route path="*" component={NotFound}/>
           </Switch>
         </React.Fragment>
       </BrowserRouter>

--- a/labellab-client/src/components/project/index.js
+++ b/labellab-client/src/components/project/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Switch } from 'react-router-dom'
+import { Switch, Route, Redirect } from 'react-router-dom'
 import Loadable from 'react-loadable'
 import { Dimmer, Loader } from 'semantic-ui-react'
 import { connect } from 'react-redux'
@@ -86,6 +86,10 @@ const Chatroom = Loadable({
   loader: () => import('./chatroom'),
   loading: Loading
 })
+const NotFound = Loadable({
+  loader: () => import('../error/notFound.js'),
+  loading: Loading
+})
 
 class ProjectIndex extends Component {
   constructor(props) {
@@ -123,6 +127,15 @@ class ProjectIndex extends Component {
     const { match, actions, history, actionsLabel } = this.props
     return (
       <React.Fragment>
+        {actions.errors ? (
+          actions.errors == '404' ? (
+            <Redirect to="/404" />
+          ) : (
+            actions.errors == '401' ? (
+              <Redirect to="/401" />
+            ) : null
+          )
+        ) : null}
         {actions.isfetching || actionsLabel.isfetching ? (
           <Dimmer active>
             <Loader indeterminate>Have some patience :)</Loader>
@@ -140,6 +153,11 @@ class ProjectIndex extends Component {
           </Sidebar>
           <div className="project-non-side-section">
             <Switch>
+              <PrivateRoute
+                exact
+                path={`${match.path}/`}
+                component={Team}
+              />
               <PrivateRoute
                 exact
                 path={`${match.path}/team`}
@@ -223,6 +241,7 @@ class ProjectIndex extends Component {
                 path={`${match.path}/chatroom/:teamId`}
                 component={Chatroom}
               />
+              <Route path="*" component={NotFound}/>
             </Switch>
           </div>
         </div>

--- a/labellab-client/src/components/project/issue/issueDetails.js
+++ b/labellab-client/src/components/project/issue/issueDetails.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, Fragment } from 'react'
+import { Redirect } from 'react-router-dom'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import {
@@ -173,6 +174,15 @@ function IssueDetails(props) {
 
     return (
         <Fragment>
+            {issuesActions.errors ? (
+                issuesActions.errors == '404' ? (
+                    <Redirect to="/404" />
+                ) : (
+                    issuesActions.errors == '401' ? (
+                        <Redirect to="/401" />
+                    ) : null
+                )
+            ) : null}
             {issuesActions.isUpdating ? (
                 <Dimmer active>
                     <Loader indeterminate>Updating issue...</Loader>

--- a/labellab-client/src/components/project/teamDetails.js
+++ b/labellab-client/src/components/project/teamDetails.js
@@ -16,7 +16,7 @@ import {
   Dropdown,
   Message
 } from 'semantic-ui-react'
-import { Link } from 'react-router-dom'
+import { Link, Redirect } from 'react-router-dom'
 
 import {
   fetchTeam,
@@ -206,6 +206,15 @@ class TeamDetails extends Component {
 
     return (
       <Fragment>
+        {teamActions.errors ? (
+          teamActions.errors == '404' ? (
+            <Redirect to="/404" />
+          ) : (
+            teamActions.errors == '401' ? (
+              <Redirect to="/401" />
+            ) : null
+          )
+        ) : null}
         {teamActions.isfetching ? (
           <Dimmer active>
             <Loader indeterminate>Have some patience </Loader>
@@ -283,11 +292,11 @@ class TeamDetails extends Component {
                     <Table.Body>
                       {team.logs
                         ? team.logs.map(log => (
-                            <Table.Row key={log.id}>
-                              <Table.Cell width={16}>{log.message}</Table.Cell>
-                              <Table.Cell width={0}></Table.Cell>
-                            </Table.Row>
-                          ))
+                          <Table.Row key={log.id}>
+                            <Table.Cell width={16}>{log.message}</Table.Cell>
+                            <Table.Cell width={0}></Table.Cell>
+                          </Table.Row>
+                        ))
                         : null}
                     </Table.Body>
                   </Table>
@@ -309,29 +318,29 @@ class TeamDetails extends Component {
                     <Table.Body>
                       {team.members
                         ? team.members.map(member => (
-                            <Table.Row key={member.id}>
-                              <Table.Cell>
-                                <Header as="h4" subheader>
-                                  {member.name}
-                                  <Header.Subheader>
-                                    {member.email}
-                                  </Header.Subheader>
-                                </Header>
-                              </Table.Cell>
-                              <Table.Cell>
-                                {roles && roles.includes('admin') ? (
-                                  <Button
-                                    icon
-                                    onClick={() =>
-                                      this.removeTeamMember(member.email)
-                                    }
-                                  >
-                                    <Icon name="user delete" />
-                                  </Button>
-                                ) : null}
-                              </Table.Cell>
-                            </Table.Row>
-                          ))
+                          <Table.Row key={member.id}>
+                            <Table.Cell>
+                              <Header as="h4" subheader>
+                                {member.name}
+                                <Header.Subheader>
+                                  {member.email}
+                                </Header.Subheader>
+                              </Header>
+                            </Table.Cell>
+                            <Table.Cell>
+                              {roles && roles.includes('admin') ? (
+                                <Button
+                                  icon
+                                  onClick={() =>
+                                    this.removeTeamMember(member.email)
+                                  }
+                                >
+                                  <Icon name="user delete" />
+                                </Button>
+                              ) : null}
+                            </Table.Cell>
+                          </Table.Row>
+                        ))
                         : null}
                     </Table.Body>
                   </Table>


### PR DESCRIPTION
# Description

Added custom 404 (Not found) and 401 (Unauthorized) error pages for urls/routes that does not exist. Earlier, going to project/issues/team and urls which did not exist, landed in a blank white page giving bad user experience.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[error handling.webm](https://user-images.githubusercontent.com/76858666/186482123-8f87343e-af6d-487b-a5e8-f054e5e36f52.webm)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
