### PR TITLE
Fix proxy port to 3000

### DIFF
--- a/labellab-client/package.json
+++ b/labellab-client/package.json
@@ -2,6 +2,7 @@
   "name": "labellab-client",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:3000",
   "dependencies": {
     "@babel/core": "7.7.4",
     "@svgr/webpack": "4.3.3",


### PR DESCRIPTION
#248 Description
Added proxy configuration in the client to forward API requests to the backend running on port 3000.

# What was changed
- Added `"proxy": "http://localhost:3000"` in `package.json`

# Reason
This fixes API call issues during local development.